### PR TITLE
Add delay to scrolling the calendar with mouse

### DIFF
--- a/client/src/features/home/CalendarPage.js
+++ b/client/src/features/home/CalendarPage.js
@@ -9,36 +9,51 @@ import { useFormModalContext } from "contexts/FormModalContext";
 import EventModal from "features/modal/EventModal";
 import { useModalContext } from "contexts/ModalContext";
 import RejectionModal from "features/modal/RejectionModal";
+import { useRef } from "react";
 
 function CalendarPage() {
   const auth = useAuthContext();
   const date = useDate();
   const formModal = useFormModalContext();
   const modal = useModalContext();
+  const canScrollRef = useRef(false);
 
   const handleWheelScroll = e => {
+    if (canScrollRef.current) return;
+    canScrollRef.current = true;
+
     if (e.deltaY > 0) {
       date.getNextMonth();
     } else {
       date.getPreviousMonth();
     }
+    setTimeout(() => {
+      canScrollRef.current = false;
+    }, 200);
   };
 
   return (
     <FormProvider>
-      <main onWheel={handleWheelScroll} className="flex flex-col gap-3 p-3 shadow-sm min-h-screen max-w-[1920px] mx-auto">
+      <main
+        onWheel={handleWheelScroll}
+        className="flex flex-col gap-3 p-3 shadow-sm min-h-screen max-w-[1920px] mx-auto"
+      >
         <CalendarHeader date={date} />
         <Calendar date={date} />
       </main>
-        <div className="md:w-1/2 mx-auto shadow-xl rounded-2xl pb-2 bg-white">
-          <Modal context={modal}>
-            <EventModal />
-          </Modal>
-            <Modal context={formModal}>
-              {auth?.user ? ( <UserForm /> ) : ( <RejectionModal handleClose={formModal.handleClose}/> )}
-            </Modal>
-        </div>
-      </FormProvider>
+      <div className="md:w-1/2 mx-auto shadow-xl rounded-2xl pb-2 bg-white">
+        <Modal context={modal}>
+          <EventModal />
+        </Modal>
+        <Modal context={formModal}>
+          {auth?.user ? (
+            <UserForm />
+          ) : (
+            <RejectionModal handleClose={formModal.handleClose} />
+          )}
+        </Modal>
+      </div>
+    </FormProvider>
   );
 }
 export default CalendarPage;

--- a/client/src/features/home/CalendarPage.js
+++ b/client/src/features/home/CalendarPage.js
@@ -16,11 +16,11 @@ function CalendarPage() {
   const date = useDate();
   const formModal = useFormModalContext();
   const modal = useModalContext();
-  const canScrollRef = useRef(false);
+  const canScrollMonthRef = useRef(true);
 
   const handleWheelScroll = e => {
-    if (canScrollRef.current) return;
-    canScrollRef.current = true;
+    if (!canScrollMonthRef.current) return;
+    canScrollMonthRef.current = false;
 
     if (e.deltaY > 0) {
       date.getNextMonth();
@@ -28,7 +28,7 @@ function CalendarPage() {
       date.getPreviousMonth();
     }
     setTimeout(() => {
-      canScrollRef.current = false;
+      canScrollMonthRef.current = true;
     }, 200);
   };
 

--- a/cypress/e2e/calendar.cy.js
+++ b/cypress/e2e/calendar.cy.js
@@ -66,6 +66,7 @@ describe("Calendar", () => {
 
     cy.get("main").trigger("wheel", { deltaY: -1 });
     tgt.calendar.currentMonthAndYear().contains("January, 2023");
+    cy.wait(200);
 
     cy.get("main").trigger("wheel", { deltaY: 1 });
     tgt.calendar.currentMonthAndYear().contains("February, 2023");

--- a/cypress/e2e/calendar.cy.js
+++ b/cypress/e2e/calendar.cy.js
@@ -72,6 +72,15 @@ describe("Calendar", () => {
     tgt.calendar.currentMonthAndYear().contains("February, 2023");
   });
 
+    it("Fast scrolling doesn't change too many months", () => {
+    setToTenthOfFebruary2023();
+
+    tgt.landing.button.calendar().click();
+    cy.get("main").trigger("wheel", { deltaY: -1 }).trigger("wheel", { deltaY: -1 });
+    tgt.calendar.currentMonthAndYear().contains("January, 2023");
+
+  });
+
   it("Shows events only for the correct month", () => {
     const now = ensureInMiddleOfMonthAndDay();
     const nextMonth = createOffsetDate(now, "Month", 1);


### PR DESCRIPTION
# Description

+ added a delay of 200ms before allowing the month to be scrolled again

## Type of change

Please select everything applicable. Please, do not delete any lines.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] This change requires an update to testing

## Issue
Closes #338 

# Checklist:

- [x] This PR is up to date with the development branch, and merge conflicts have been resolved
- [x] I have executed `npm run test-frontend` and all tests have passed successfully or I have included details within my PR on the failure
- [x] I have executed `npm run lint` and resolved any outstanding errors. Most issues can be solved by executing `npm run format`
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
