### PR TITLE
fixed event times from overlapping

### DIFF
--- a/client/src/features/calendar/Event.js
+++ b/client/src/features/calendar/Event.js
@@ -20,7 +20,7 @@ const Event = props => {
           props.event.confirmed ? confirmedCss : unconfirmedCSss
         } rounded-full`}
       ></span>
-      <span className="ml-2 font-light leading-none">
+      <span className="ml-2 text-xs font-light leading-none whitespace-nowrap">
         {formatToLocalTime(props.event.startAt)}
       </span>
       <span className="ml-2 font-medium leading-none truncate">


### PR DESCRIPTION
# Description

Added tailwind classes "text-xs" and "whitespace-nowrap" to prevent overlapping of spans. 

npm run test-frontend is falling due some issue with Windows.

## Type of change

Please select everything applicable. Please, do not delete any lines.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change requires an update to testing

## Issue

- [x] Is this related to a specific issue? If so, please specify:  #349 

# Checklist:

- [x] This PR is up to date with the development branch, and merge conflicts have been resolved
- [ ] I have executed `npm run test-frontend` and all tests have passed successfully or I have included details within my PR on the failure -> test is falling due some issue with Windows
- [x] I have executed `npm run lint` and resolved any outstanding errors. Most issues can be solved by executing `npm run format`
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
