### PR TITLE
change text color of Sat and Sun to orange #E0835D

### DIFF
--- a/client/src/features/calendar/AllDays.js
+++ b/client/src/features/calendar/AllDays.js
@@ -8,8 +8,8 @@ const AllDays = () => {
       <div className="pl-1 text-md font-bold">Wed</div>
       <div className="pl-1 text-md font-bold">Thu</div>
       <div className="pl-1 text-md font-bold">Fri</div>
-      <div className="pl-1 text-md font-bold">Sat</div>
-      <div className="pl-1 text-md font-bold">Sun</div>
+      <div className="pl-1 text-md font-bold text-[#E0835D]">Sat</div>
+      <div className="pl-1 text-md font-bold text-[#E0835D]">Sun</div>
     </div>
   );
 };


### PR DESCRIPTION
# Description

I changed the text color for Saturday and Sunday to orange #E0835D on the calendar days.

## Type of change

Please select everything applicable. Please, do not delete any lines.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change requires an update to testing

## Issue

- [x] Is this related to a specific issue? If so, please specify: #347 

# Checklist:

- [x] This PR is up to date with the development branch, and merge conflicts have been resolved
- [x] I have executed `npm run test-frontend` and all tests have passed successfully or I have included details within my PR on the failure
- [x] I have executed `npm run lint` and resolved any outstanding errors. Most issues can be solved by executing `npm run format`
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
