### PR TITLE
Feature/issue 366

### DIFF
--- a/client/src/contexts/EventsContext/useProvideEvents.js
+++ b/client/src/contexts/EventsContext/useProvideEvents.js
@@ -1,7 +1,10 @@
-import { useState } from "react";
+import { useRef, useState } from "react";
 
 const useProvideEvents = () => {
   const [events, setEvents] = useState([]);
+
+  // cache to store api call arguments
+  const cache = useRef([]);
 
   const addEvents = newEvents => {
     setEvents([...events, ...newEvents]);
@@ -9,6 +12,7 @@ const useProvideEvents = () => {
 
   return {
     events,
+    cache,
     setEvents,
     addEvents,
   };

--- a/client/src/features/calendar/Calendar.js
+++ b/client/src/features/calendar/Calendar.js
@@ -70,7 +70,7 @@ const Calendar = ({ date }) => {
   }, [setEvents, date.monthStart, date.monthEnd]);
 
   // Render nothing while fetching for data from server
-  if (status === Status.LOADING) return null;
+  // if (status === Status.LOADING) return null;
 
   return (
     <div className="flex flex-grow h-full w-full overflow-auto text-gray-700 bg-white">

--- a/client/src/features/calendar/Calendar.js
+++ b/client/src/features/calendar/Calendar.js
@@ -1,17 +1,35 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useRef } from "react";
 // components
 import AllDays from "./AllDays";
 import DayCardList from "./DayCardList";
 // Utility functions
 // For getting real data
 import DataService from "services/dataService";
-import { getEventsByDayNumber } from "utilities/calendar";
+import { getMatchMonthAndYear, getEventsByDayNumber } from "utilities/calendar";
 import { parse } from "date-fns";
 import { useEventsContext } from "contexts/EventsContext";
 
+const Status = {
+  IDLE: "idle",
+  LOADING: "loading",
+  RESOLVED: "resolved",
+  REJECTED: "rejected",
+};
+
 const Calendar = ({ date }) => {
   const { events, setEvents } = useEventsContext();
-  const [loading, setLoading] = useState(true);
+  // status and errors or api calls
+  const [status, setStatus] = useState(Status.IDLE);
+  const [error, setError] = useState(null);
+  // cache to store api call arguments
+  const cache = useRef([]);
+
+  const eventsInSelectedMonth = getMatchMonthAndYear(
+    date.month,
+    date.year,
+    events
+  );
+
   // An array of days containing events for populating the calendar
   const days = Array.from({ length: date.daysInMonth }, (_, i) => {
     const currentDay = i + 1;
@@ -24,28 +42,41 @@ const Calendar = ({ date }) => {
     );
     return {
       date: dateObject,
-      events: getEventsByDayNumber(currentDay, events),
+      events: getEventsByDayNumber(currentDay, eventsInSelectedMonth),
     };
   });
 
   useEffect(() => {
-    setLoading(true);
     // Fetch events from server
     const fetch = async () => {
       // Database data from server
       const response = await DataService.getAll(date.monthStart, date.monthEnd);
-      setEvents(response.data);
+      return response.data;
     };
-
-    fetch().then(setLoading(false)).catch(setLoading(false));
-  }, [setEvents, date]);
+    // if the same call has already been made, do not repeat it
+    if (!cache.current.includes(date.monthStart)) {
+      setStatus(Status.LOADING);
+      cache.current.push(date.monthStart);
+      fetch()
+        .then(data => {
+          setEvents(prev => [...prev, ...data]);
+          setStatus(Status.RESOLVED);
+        })
+        .catch(error => {
+          setError(error.message);
+          setStatus(Status.REJECTED);
+        });
+    }
+  }, [setEvents, date.monthStart, date.monthEnd]);
 
   // Render nothing while fetching for data from server
-  if (loading) return null;
+  if (status === Status.LOADING) return null;
 
   return (
     <div className="flex flex-grow h-full w-full overflow-auto text-gray-700 bg-white">
       <div className="flex flex-col flex-grow">
+        {/* render error message if there was an error fetching data */}
+        {status === Status.REJECTED && <div>{error}</div>}
         <AllDays />
         <DayCardList data={days} firstDayOfMonth={date.firstDay} />
       </div>

--- a/client/src/features/calendar/Calendar.js
+++ b/client/src/features/calendar/Calendar.js
@@ -5,18 +5,13 @@ import DayCardList from "./DayCardList";
 // Utility functions
 // For getting real data
 import DataService from "services/dataService";
-import { getMatchMonthAndYear, getEventsByDayNumber } from "utilities/calendar";
+import { getEventsByDayNumber } from "utilities/calendar";
 import { parse } from "date-fns";
 import { useEventsContext } from "contexts/EventsContext";
 
 const Calendar = ({ date }) => {
   const { events, setEvents } = useEventsContext();
   const [loading, setLoading] = useState(true);
-  const eventsInSelectedMonth = getMatchMonthAndYear(
-    date.month,
-    date.year,
-    events
-  );
   // An array of days containing events for populating the calendar
   const days = Array.from({ length: date.daysInMonth }, (_, i) => {
     const currentDay = i + 1;
@@ -29,7 +24,7 @@ const Calendar = ({ date }) => {
     );
     return {
       date: dateObject,
-      events: getEventsByDayNumber(currentDay, eventsInSelectedMonth),
+      events: getEventsByDayNumber(currentDay, events),
     };
   });
 
@@ -38,12 +33,12 @@ const Calendar = ({ date }) => {
     // Fetch events from server
     const fetch = async () => {
       // Database data from server
-      const response = await DataService.getAll();
+      const response = await DataService.getAll(date.monthStart, date.monthEnd);
       setEvents(response.data);
     };
 
     fetch().then(setLoading(false)).catch(setLoading(false));
-  }, [setEvents]);
+  }, [setEvents, date]);
 
   // Render nothing while fetching for data from server
   if (loading) return null;

--- a/client/src/features/calendar/Calendar.js
+++ b/client/src/features/calendar/Calendar.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from "react";
+import React, { useState, useEffect } from "react";
 // components
 import AllDays from "./AllDays";
 import DayCardList from "./DayCardList";
@@ -17,12 +17,10 @@ const Status = {
 };
 
 const Calendar = ({ date }) => {
-  const { events, setEvents } = useEventsContext();
+  const { events, setEvents, cache } = useEventsContext();
   // status and errors or api calls
   const [status, setStatus] = useState(Status.IDLE);
   const [error, setError] = useState(null);
-  // cache to store api call arguments
-  const cache = useRef([]);
 
   const eventsInSelectedMonth = getMatchMonthAndYear(
     date.month,
@@ -67,7 +65,7 @@ const Calendar = ({ date }) => {
           setStatus(Status.REJECTED);
         });
     }
-  }, [setEvents, date.monthStart, date.monthEnd]);
+  }, [setEvents, date.monthStart, date.monthEnd, cache]);
 
   // Render nothing while fetching for data from server
   // if (status === Status.LOADING) return null;

--- a/client/src/hooks/useDate.js
+++ b/client/src/hooks/useDate.js
@@ -12,6 +12,8 @@ const useDate = () => {
   const year = getYear(date);
   // Month in string format; e.g. 'November'
   const month = format(date, "LLLL");
+  const monthStart = new Date(date.getFullYear(), date.getMonth()).getTime();
+  const monthEnd = new Date(date.getFullYear(), date.getMonth() + 1).getTime();
   const daysInMonth = getDaysInMonth(date);
   // First day of the month; e.g. 'Tue'
   const firstDay = format(startOfMonth(date), "E");
@@ -27,6 +29,8 @@ const useDate = () => {
   return {
     year,
     month,
+    monthStart,
+    monthEnd,
     daysInMonth,
     firstDay,
     getNextMonth,

--- a/client/src/services/dataService.js
+++ b/client/src/services/dataService.js
@@ -8,8 +8,8 @@ class DataService {
   create(msg) {
     return URL.post(`/events/`, msg);
   }
-  getAll() {
-    return URL.get("/events");
+  getAll(from, to) {
+    return URL.get("/events", { params: { from, to } });
   }
   getById(id) {
     return URL.get(`/events/${id}`);

--- a/client/src/utilities/calendar.js
+++ b/client/src/utilities/calendar.js
@@ -1,17 +1,5 @@
 import { parseISO, format } from "date-fns";
 
-export const getMatchMonthAndYear = (monthToMatch, yearToMatch, events) => {
-  if (!events.length) return [];
-
-  const allMatchedEvents = events.filter(event => {
-    const isoDate = parseISO(event.startAt);
-    const monthInString = format(isoDate, "LLLL"); // December
-    const year = isoDate.getFullYear();
-    return monthToMatch === monthInString && year === yearToMatch;
-  });
-  return allMatchedEvents;
-};
-
 export const getEventsByDayNumber = (currentDay, allEvents) => {
   if (!allEvents.length) return [];
 

--- a/client/src/utilities/calendar.js
+++ b/client/src/utilities/calendar.js
@@ -1,5 +1,17 @@
 import { parseISO, format } from "date-fns";
 
+export const getMatchMonthAndYear = (monthToMatch, yearToMatch, events) => {
+  if (!events.length) return [];
+
+  const allMatchedEvents = events.filter(event => {
+    const isoDate = parseISO(event.startAt);
+    const monthInString = format(isoDate, "LLLL"); // December
+    const year = isoDate.getFullYear();
+    return monthToMatch === monthInString && year === yearToMatch;
+  });
+  return allMatchedEvents;
+};
+
 export const getEventsByDayNumber = (currentDay, allEvents) => {
   if (!allEvents.length) return [];
 

--- a/server/controllers/events.js
+++ b/server/controllers/events.js
@@ -35,12 +35,7 @@ module.exports = {
       // load all events
       dbQuery = {};
     } else {
-      dbQuery = {
-        $or: [
-          { startAt: { $gte: from, $lt: to } },
-          { endAt: { $gte: from, $lt: to } },
-        ],
-      };
+      dbQuery = { startAt: { $gte: from, $lt: to } };
     }
 
     const events = await Event.find(dbQuery)

--- a/server/controllers/events.js
+++ b/server/controllers/events.js
@@ -27,13 +27,27 @@ module.exports = {
     res.status(201).json({ message: "Event created!", events: addedEvents });
   },
   getAll: async (req, res) => {
-    // Get an array of ALL events
-    const events = await Event.find()
+    // start and end are expected to be timestamps or ISO dates
+    const { from, to } = req.query;
+
+    let dbQuery;
+    if (!from && !to) {
+      // load all events
+      dbQuery = {};
+    } else {
+      dbQuery = {
+        $or: [
+          { startAt: { $gte: from, $lt: to } },
+          { endAt: { $gte: from, $lt: to } },
+        ],
+      };
+    }
+
+    const events = await Event.find(dbQuery)
       .populate("user", "displayName")
       .lean()
       .exec();
 
-    // return all events
     res.json(events);
   },
   getOne: async (req, res) => {

--- a/server/test/acceptance/routes.test.js
+++ b/server/test/acceptance/routes.test.js
@@ -3,6 +3,7 @@ const app = require("../../app");
 const {
   validFormDataNonRecurr,
   validFormDataRecurr,
+  startIn5Days,
 } = require("../unit/validateBodyMockData");
 
 const { Database } = require("../utils");
@@ -26,7 +27,7 @@ describe("event routes", () => {
       expect(res.body).toHaveLength(0);
     });
 
-    it("should return an array of events if they exist", async () => {
+    it("should return an array of all events", async () => {
       const resPost = await request(app)
         .post("/events")
         .send(validFormDataNonRecurr);
@@ -36,6 +37,25 @@ describe("event routes", () => {
       expect(res.statusCode).toBe(200);
       expect(res.body).toBeInstanceOf(Array);
       expect(res.body).toHaveLength(1);
+    });
+
+    it("should return an array of events in specified date range", async () => {
+      await request(app).post("/events").send(startIn5Days);
+
+      const now = new Date();
+      const start = now.getTime();
+      const in3Days = new Date().setDate(now.getDate() + 3);
+      const in10Days = new Date().setDate(now.getDate() + 10);
+
+      const res = await request(app).get(`/events?from=${start}&to=${in3Days}`);
+      expect(res.statusCode).toBe(200);
+      expect(res.body).toHaveLength(0);
+
+      const res2 = await request(app).get(
+        `/events?from=${in3Days}&to=${in10Days}`
+      );
+      expect(res2.statusCode).toBe(200);
+      expect(res2.body).toHaveLength(1);
     });
   });
 

--- a/server/test/unit/validateBodyMockData.js
+++ b/server/test/unit/validateBodyMockData.js
@@ -24,7 +24,7 @@ const timeNow = Temporal.Now.plainTimeISO().round({
   smallestUnit: "minute",
   roundingMode: "ceil",
 });
-const timeIn1hour = timeNow.subtract({ hours: 1 });
+const timeIn1hour = timeNow.add({ hours: 1 });
 
 const validFormDataNonRecurr = {
   title: "test",
@@ -119,6 +119,12 @@ const invalidDayName = {
   recurring: { rate: "weekly", days: ["January!"] },
 };
 
+const startIn5Days = {
+  ...validFormDataNonRecurr,
+  initialDate: dateIn5Days.toString(),
+  finalDate: dateIn5Days.toString(),
+};
+
 module.exports = {
   validFormDataNonRecurr,
   validFormDataRecurr,
@@ -135,4 +141,5 @@ module.exports = {
   invalidRate,
   invalidNonRecurDays,
   invalidDayName,
+  startIn5Days,
 };


### PR DESCRIPTION
# Description

Current behavior: when the calendar is opened all events from the database are fetched.
New behavior: events are loaded only for the current month. If you move to the next/previous month a new request to the backend is made for that month. Events are added to the state, so no new request is made if you switch back.

## Type of change

Please select everything applicable. Please, do not delete any lines.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change requires an update to testing

## Issue

- [x] Is this related to a specific issue? If so, please specify: #366 

# Checklist:

- [x] This PR is up to date with the main branch, and merge conflicts have been resolved
- [x] I have executed `npm run test` and all tests have passed successfully or I have included details within my PR on the failure.
- [x] I have executed `npm run lint` and resolved any outstanding errors. Most issues can be solved by executing `npm run format`
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
