### PR TITLE
fix: prevent sending user data to guests

### DIFF
--- a/server/controllers/events.js
+++ b/server/controllers/events.js
@@ -26,21 +26,28 @@ module.exports = {
 
     res.status(201).json({ message: "Event created!", events: addedEvents });
   },
+
   getAll: async (req, res) => {
-    // Get an array of ALL events
-    const events = await Event.find()
-      .populate("user", "displayName")
-      .lean()
-      .exec();
+    // Build Mongoose query
+    // If user is not authenticated, exclude event creator's name and id
+    const query = !req.user
+      ? Event.find().select("-user")
+      : Event.find().populate("user", "displayName");
+
+    const events = await query.lean();
 
     // return all events
     res.json(events);
   },
+
   getOne: async (req, res) => {
     const { id } = req.params;
 
     // Get event by id
-    const event = await Event.findById(id).lean().exec();
+    const event = await Event.findById(id)
+      .select(req.user ? "" : "-user")
+      .lean()
+      .exec();
 
     // Check if event exists
     if (!event) {
@@ -49,6 +56,7 @@ module.exports = {
 
     res.json(event);
   },
+
   deleteEvent: async (req, res) => {
     const { id } = req.params;
 
@@ -63,6 +71,7 @@ module.exports = {
 
     res.sendStatus(204);
   },
+
   deleteAllEvents: async (req, res) => {
     const { groupId } = req.params;
 

--- a/server/test/acceptance/routes.test.js
+++ b/server/test/acceptance/routes.test.js
@@ -68,10 +68,7 @@ describe("event routes", () => {
     });
 
     it("returns array of events and excludes user data when accessed as a guest", async () => {
-      const agent = request.agent(app);
-      const resPost = await request(app)
-        .post("/events")
-        .send(validFormDataNonRecurr);
+      await request(app).post("/events").send(validFormDataNonRecurr);
 
       const eventsRes = await asGuest(async () => {
         return request(app).get("/events");

--- a/server/test/utils.js
+++ b/server/test/utils.js
@@ -2,6 +2,8 @@
 
 const mongoose = require("mongoose");
 const { MongoMemoryServer } = require("mongodb-memory-server");
+const request = require("supertest");
+const app = require("../app");
 
 class Database {
   async setUp() {
@@ -32,4 +34,28 @@ class Database {
   }
 }
 
-module.exports = { Database };
+/*
+ * A simple higher-order function to run test code as a guest (non-authenticated user).
+ *
+ * @param {Function} callback - The code block to execute.
+ * @param {Object} [agent=null] - The request agent to use.
+ * @returns {Promise} - Resolves with the return value of the callback.
+ */
+async function asGuest(callback, agent = null) {
+  try {
+    process.env.MOCK_USER = "false";
+
+    if (agent) {
+      await request.agent(app).get("/auth/logout");
+    }
+
+    return await callback();
+  } finally {
+    process.env.MOCK_USER = "true";
+  }
+}
+
+module.exports = {
+  Database,
+  asGuest,
+};


### PR DESCRIPTION
# Description

Guests shouldn't be able to see the name of those who created an event. While the UI respected that, the data was still being sent from the server and that data was visible in devtools.

![image](https://user-images.githubusercontent.com/1634972/225160552-53a3ce39-0fa0-496f-a25b-756e72426040.png)

Didn't run frontend tests, didn't have deps installed to do so. 

## Type of change

Please select everything applicable. Please, do not delete any lines.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [X] This change requires an update to testing

## Issue

- [ ] Is this related to a specific issue? If so, please specify:

# Checklist:

- [X] This PR is up to date with the main branch, and merge conflicts have been resolved
- [X] I have executed `npm run test` and all tests have passed successfully or I have included details within my PR on the failure.
- [X] I have executed `npm run lint` and resolved any outstanding errors. Most issues can be solved by executing `npm run format`
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
