### PR TITLE
Remove Discord tag from user greeting

### DIFF
--- a/client/src/features/home/LongCard.js
+++ b/client/src/features/home/LongCard.js
@@ -17,7 +17,7 @@ const LongCard = ({ heading, title, description, img }) => {
       <div className="flex flex-col items-center gap-8 text-center w-full lg:max-w-xl">
         {/* Display "heading, username" if logged in, or just the heading if logged out */}
         <h1 className="text-2xl font-bold lg:text-3xl xl:text-4xl">
-          {auth.user ? `${heading}, ${auth.user?.displayName.split('#')[0]}!` : `${heading}!`}
+          {auth.user ? `${heading}, ${auth.user?.displayName?.split('#')[0]}!` : `${heading}!`}
         </h1>
         <p className="px-10 font-medium">
           <span className="font-bold">{title}</span>

--- a/client/src/features/home/LongCard.js
+++ b/client/src/features/home/LongCard.js
@@ -17,7 +17,7 @@ const LongCard = ({ heading, title, description, img }) => {
       <div className="flex flex-col items-center gap-8 text-center w-full lg:max-w-xl">
         {/* Display "heading, username" if logged in, or just the heading if logged out */}
         <h1 className="text-2xl font-bold lg:text-3xl xl:text-4xl">
-          {auth.user ? `${heading}, ${auth.user?.displayName}!` : `${heading}!`}
+          {auth.user ? `${heading}, ${auth.user?.displayName.split('#')[0]}!` : `${heading}!`}
         </h1>
         <p className="px-10 font-medium">
           <span className="font-bold">{title}</span>


### PR DESCRIPTION
# Description

### What

This change would remove the Discord tag ("#0000") from the name the user is greeted with on the landing page.

"Welcome, Bob Coder#1234!" -> "**Welcome, Bob Coder!**"


### Why

Personally I think this makes the greeting cleaner and more professional. Please reject the PR if you disagree.

### How

> The `split()` method takes a pattern and divides a `String` into an ordered list of substrings by searching for the pattern, puts these substrings into an array, and returns the array.

Then by indexing with `[0]` we get everything before the `#` symbol.

## Type of change

Please select everything applicable. Please, do not delete any lines.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change requires an update to testing

## Issue

- [x] Is this related to a specific issue? If so, please specify:
Kind of? It's related to #337
as well as #353

# Checklist:

- [x] This PR is up to date with the main branch, and merge conflicts have been resolved
- [ ] I have executed `npm run test` and all tests have passed successfully or I have included details within my PR on the failure.
- [ ] I have executed `npm run lint` and resolved any outstanding errors. Most issues can be solved by executing `npm run format`
- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
