### PR TITLE
Fixed new style discord usernames not displaying correctly - 426

### DIFF
--- a/server/config/passport.js
+++ b/server/config/passport.js
@@ -28,7 +28,7 @@ module.exports = function (passport) {
       },
       async function (currentReq, accessToken, refreshToken, profile, cb) {
         const displayName =
-          `${profile.discriminator}`.length === 4
+          profile.discriminator.length === 4
             ? `${profile.username}#${profile.discriminator}`
             : profile.username;
         const is100Dever = profile.guilds.some(

--- a/server/config/passport.js
+++ b/server/config/passport.js
@@ -27,7 +27,10 @@ module.exports = function (passport) {
         passReqToCallback: true,
       },
       async function (currentReq, accessToken, refreshToken, profile, cb) {
-        const displayName = `${profile.username}#${profile.discriminator}`;
+        const displayName =
+          `${profile.discriminator}`.length === 4
+            ? `${profile.username}#${profile.discriminator}`
+            : profile.username;
         const is100Dever = profile.guilds.some(
           server => server.id === "735923219315425401"
         );


### PR DESCRIPTION
# Description

This is a simple fix to correct the new style Discord usernames not displaying correctly. I changed the `displayName` variable to check the length of the discriminator. If the length is 4, the `displayName` includes it, otherwise the `displayName` will only include the profile username.

## Type of change

Please select everything applicable. Please, do not delete any lines.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change requires an update to testing

## Issue

- [x] Is this related to a specific issue? If so, please specify: fixes #426

# Checklist:

- [x] This PR is up to date with the main branch, and merge conflicts have been resolved
- [x] I have executed `npm run test` and all tests have passed successfully or I have included details within my PR on the failure.
- [x] I have executed `npm run lint` and resolved any outstanding errors. Most issues can be solved by executing `npm run format`
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
