### PR TITLE
Feature/admin dashboard visualize group events 413

### DIFF
--- a/client/src/features/adminDashboard/EventCard.js
+++ b/client/src/features/adminDashboard/EventCard.js
@@ -1,0 +1,18 @@
+import React from "react";
+
+function EventCard({ event }) {
+  return (
+    <div key={event.id} className="event bg-primary my-4 p-4 rounded-xl">
+      <ul className="font-inconsolata">
+        <li className="text-2xl md:text-3xl lg:text-4xl font-bold">
+          {event.title}
+        </li>
+        <li className="text-mainBlue">{event.description}</li>
+        <hr className="border-teal-light" />
+        <li>Scheduled by: {event.user.displayName}</li>
+      </ul>
+    </div>
+  );
+}
+
+export default EventCard;

--- a/client/src/features/adminDashboard/EventCard.js
+++ b/client/src/features/adminDashboard/EventCard.js
@@ -2,7 +2,10 @@ import React from "react";
 
 function EventCard({ event }) {
   return (
-    <div key={event.id} className="event bg-primary my-4 p-4 rounded-xl">
+    <section
+      key={event.id}
+      className="single-event bg-primary my-4 p-4 rounded-xl"
+    >
       <ul className="font-inconsolata">
         <li className="text-2xl md:text-3xl lg:text-4xl font-bold">
           {event.title}
@@ -11,7 +14,7 @@ function EventCard({ event }) {
         <hr className="border-teal-light" />
         <li>Scheduled by: {event.user.displayName}</li>
       </ul>
-    </div>
+    </section>
   );
 }
 

--- a/client/src/features/adminDashboard/EventCard.js
+++ b/client/src/features/adminDashboard/EventCard.js
@@ -12,7 +12,7 @@ function EventCard({ event }) {
         </li>
         <li className="text-mainBlue">{event.description}</li>
         <hr className="border-teal-light" />
-        <li>Scheduled by: {event.user.displayName}</li>
+        <li>Scheduled by: {event.user?.displayName || "UNKNOWN"}</li>
       </ul>
     </section>
   );

--- a/client/src/features/adminDashboard/GroupEventCard.js
+++ b/client/src/features/adminDashboard/GroupEventCard.js
@@ -3,7 +3,7 @@ import EventCard from "features/adminDashboard/EventCard";
 
 function GroupEventCard({ events }) {
   return (
-    <section className="group-event ml-4">
+    <section className="group-event">
       <EventCard key={events[0]._id} event={events[0]} />
     </section>
   );

--- a/client/src/features/adminDashboard/GroupEventCard.js
+++ b/client/src/features/adminDashboard/GroupEventCard.js
@@ -1,0 +1,12 @@
+import React from "react";
+import EventCard from "features/adminDashboard/EventCard";
+
+function GroupEventCard({ events }) {
+  return (
+    <section className="group-event ml-4">
+      <EventCard key={events[0]._id} event={events[0]} />
+    </section>
+  );
+}
+
+export default GroupEventCard;

--- a/client/src/pages/AdminDashboard.js
+++ b/client/src/pages/AdminDashboard.js
@@ -2,15 +2,39 @@ import React from "react";
 import { useEffect, useState } from "react";
 import "index.css";
 import DataService from "services/dataService";
+import EventCard from "features/adminDashboard/EventCard";
+import GroupEventCard from "features/adminDashboard/GroupEventCard";
 
 export const AdminDashboard = () => {
-  const [allEvents, setAllEvents] = useState({});
+  const [singleEvents, setSingleEvents] = useState({});
+  const [groupEvents, setGroupEvents] = useState({});
   const [loading, setLoading] = useState(false);
 
   const handleGetAllEvents = async () => {
     setLoading(true);
     const response = await DataService.getAll();
-    setAllEvents(response.data);
+
+    // Filter only single events
+    setSingleEvents(response.data.filter(e => e.groupId === null));
+
+    // Group remaining events by groupId
+    let gEvents = response.data.reduce((map, event) => {
+      // Ignore events without a groupId
+      if (event.groupId === null) {
+        return map;
+      }
+
+      // Collect events with a groupId
+      if (event.groupId in map) {
+        map[event.groupId].push(event);
+      } else {
+        map[event.groupId] = [event];
+      }
+
+      return map;
+    }, {});
+
+    setGroupEvents(gEvents);
     setLoading(false);
   };
 
@@ -20,7 +44,7 @@ export const AdminDashboard = () => {
     fetch();
   }, []);
 
-  let eventStatus = loading ? "LOADING..." : Object.keys(allEvents).length;
+  let eventStatus = loading ? "LOADING..." : Object.keys(singleEvents).length;
   return (
     <div className="flex flex-col h-100 min-h-screen w-full p-4 bg-primary">
       <div className="border-b-2 border-mainOrange border-dotted flex justify-between py-2">
@@ -35,29 +59,33 @@ export const AdminDashboard = () => {
           🗘 Refresh Events
         </button>
       </div>
-      <div id="events" className="h-full mt-2">
-        {/* Display all events in an unordered list when the data is finished loading */}
-        {loading ||
-          Object.keys(allEvents).map(key => {
-            return (
-              <div
-                key={allEvents[key].id}
-                className="event bg-primary my-4 p-4 rounded-xl"
-              >
-                <ul className="font-inconsolata">
-                  <li className="text-2xl md:text-3xl lg:text-4xl font-bold">
-                    {allEvents[key].title}
-                  </li>
-                  <li className="text-mainBlue">
-                    {allEvents[key].description}
-                  </li>
-                  <hr className="border-teal-light" />
-                  <li>Scheduled by: {allEvents[key].user.displayName}</li>
-                </ul>
-              </div>
-            );
-          })}
-      </div>
+      <section id="events" className="h-full mt-2">
+        <section id="single-events">
+          {/* Display all events in an unordered list when the data is finished loading */}
+          {loading ||
+            Object.keys(singleEvents).map(key => {
+              return (
+                <EventCard
+                  key={singleEvents[key]._id}
+                  event={singleEvents[key]}
+                />
+              );
+            })}
+        </section>
+        <h2>RECURRING EVENTS ({Object.keys(groupEvents).length})</h2>
+        <hr />
+        <section id="group-events">
+          {loading ||
+            Object.keys(groupEvents).map(key => {
+              return (
+                <GroupEventCard
+                  key={groupEvents[key]._id}
+                  events={groupEvents[key]}
+                />
+              );
+            })}
+        </section>
+      </section>
     </div>
   );
 };

--- a/client/src/pages/AdminDashboard.js
+++ b/client/src/pages/AdminDashboard.js
@@ -59,7 +59,12 @@ export const AdminDashboard = () => {
           🗘 Refresh Events
         </button>
       </div>
-      <section id="events" className="h-full mt-2">
+      <section id="events" className="h-full mt-2 bg-teal-light rounded-lg p-4">
+        <h2 className="font-bold font-inconsolata text-2xl md:text-3xl lg:text-4xl text-teal">
+          Singular Events (
+          <span className="event-count">{Object.keys(groupEvents).length}</span>
+          )
+        </h2>
         <section id="single-events">
           {/* Display all events in an unordered list when the data is finished loading */}
           {loading ||
@@ -72,9 +77,15 @@ export const AdminDashboard = () => {
               );
             })}
         </section>
-        <h2>RECURRING EVENTS ({Object.keys(groupEvents).length})</h2>
-        <hr />
         <section id="group-events">
+          <h2 className="font-bold font-inconsolata text-2xl md:text-3xl lg:text-4xl text-teal">
+            Recurring Events (
+            <span className="event-count">
+              {Object.keys(groupEvents).length}
+            </span>
+            )
+          </h2>
+          <hr />
           {loading ||
             Object.keys(groupEvents).map(key => {
               return (

--- a/client/src/pages/AdminDashboard.js
+++ b/client/src/pages/AdminDashboard.js
@@ -44,7 +44,15 @@ export const AdminDashboard = () => {
     fetch();
   }, []);
 
-  let eventStatus = loading ? "LOADING..." : Object.keys(singleEvents).length;
+  const singleEventCount = loading
+    ? "LOADING..."
+    : Object.keys(singleEvents).length;
+  const groupEventCount = loading
+    ? "LOADING..."
+    : Object.keys(groupEvents).length;
+  const eventStatus = loading
+    ? "LOADING..."
+    : singleEventCount + groupEventCount;
   return (
     <div className="flex flex-col h-100 min-h-screen w-full p-4 bg-primary">
       <div className="border-b-2 border-mainOrange border-dotted flex justify-between py-2">
@@ -59,12 +67,12 @@ export const AdminDashboard = () => {
           🗘 Refresh Events
         </button>
       </div>
-      <section id="events" className="h-full mt-2 bg-teal-light rounded-lg p-4">
+      <section id="events" className="h-full my-2 bg-teal-light rounded-lg p-4">
         <h2 className="font-bold font-inconsolata text-2xl md:text-3xl lg:text-4xl text-teal">
           Singular Events (
-          <span className="event-count">{Object.keys(groupEvents).length}</span>
-          )
+          <span className="event-count">{singleEventCount}</span>)
         </h2>
+        <hr />
         <section id="single-events">
           {/* Display all events in an unordered list when the data is finished loading */}
           {loading ||
@@ -80,10 +88,7 @@ export const AdminDashboard = () => {
         <section id="group-events">
           <h2 className="font-bold font-inconsolata text-2xl md:text-3xl lg:text-4xl text-teal">
             Recurring Events (
-            <span className="event-count">
-              {Object.keys(groupEvents).length}
-            </span>
-            )
+            <span className="event-count">{groupEventCount}</span>)
           </h2>
           <hr />
           {loading ||

--- a/cypress/e2e/admin-dashboard.cy.js
+++ b/cypress/e2e/admin-dashboard.cy.js
@@ -5,31 +5,59 @@ import tgt from "../support/tgt";
 // Generate test event
 const TEST_EVENT_AUTHOR = "100_DEVER";
 const TEST_EVENT_GROUP_ID = "admin_text_event_id";
-const TEST_EVENTS = [
+const SINGULAR_TEST_EVENTS = [
   {
-    title: "1st EVENT",
-    description: "1st Description",
+    title: "1st SINGULAR EVENT",
+    description: "1st Singular Description",
     location: "1st Location",
-    groupId: TEST_EVENT_GROUP_ID,
+    groupId: null,
     startAt: Date.now(),
-    endAt: Date.now() + 3600,
+    endAt: Date.now() + 60 * 60,
   },
   {
-    title: "2nd EVENT",
-    description: "2nd Description",
+    title: "2nd SINGULAR EVENT",
+    description: "2nd Singular Description",
     location: "2nd Location",
-    groupId: TEST_EVENT_GROUP_ID,
-    startAt: Date.now(),
-    endAt: Date.now() + 3600,
+    groupId: null,
+    startAt: Date.now() + 60 * 60,
+    endAt: Date.now() + 60 * 60 * 2,
   },
 ];
 
-const addTestEvents = (test_events = TEST_EVENTS) => {
+const GROUP_TEST_EVENTS = [
+  {
+    title: "1st GROUP EVENT",
+    description: "1st Group Description",
+    location: "1st Location",
+    groupId: TEST_EVENT_GROUP_ID,
+    startAt: Date.now(),
+    endAt: Date.now() + 60 * 60,
+  },
+  {
+    title: "2nd GROUP EVENT",
+    description: "2nd Group Description",
+    location: "2nd Location",
+    groupId: TEST_EVENT_GROUP_ID,
+    startAt: Date.now() + 60 * 60 * 24,
+    endAt: Date.now() + 60 * 60 * 24 + 3600,
+  },
+];
+
+const GROUP_EVENT_COUNTS_BY_GROUP_ID = GROUP_TEST_EVENTS.reduce(
+  (acc, event) => {
+    acc[event.groupId] = acc[event.groupId] || 0;
+    return { [event.groupId]: acc[event.groupId] + 1, ...acc };
+  },
+  {}
+);
+
+const addTestEvents = test_events => {
   cy.url().then(return_url => {
     cy.visit("/");
 
     // Generate test events
     cy.createOwnEvents(TEST_EVENT_AUTHOR, ...test_events);
+    // TODO add group events
 
     // Close event creation modal
     tgt.modal.close();
@@ -53,7 +81,7 @@ describe("Admin Dashboard", () => {
     cy.get("h1").contains("Admin Dashboard");
   });
 
-  describe("Add Events", () => {
+  describe("Add events", () => {
     before(() => {
       // Navigate to admin dashboard
       cy.visit("/admindashboard");
@@ -64,29 +92,29 @@ describe("Admin Dashboard", () => {
     });
     beforeEach(() => {
       // Add test events
-      addTestEvents(TEST_EVENTS);
+      addTestEvents([...SINGULAR_TEST_EVENTS, ...GROUP_TEST_EVENTS]);
 
       // Navigate to admin dashboard
       cy.visit("/admindashboard");
     });
 
-    it("Event titles and descriptions", () => {
-      TEST_EVENTS.forEach((test_event, i) => {
+    it("Single event titles and descriptions", () => {
+      SINGULAR_TEST_EVENTS.forEach((test_event, i) => {
         // Ensure test events rendered with correct title
         cy.get("#events")
-          .find(`.event:nth-of-type(${i + 1}) li:nth-of-type(1)`)
+          .find(`.single-event:nth-of-type(${i + 1}) li:nth-of-type(1)`)
           .invoke("text")
           .should("contain", test_event.title);
 
         // Ensure test event rendered with correct description
         cy.get("#events")
-          .find(`.event:nth-of-type(${i + 1}) li:nth-of-type(2)`)
+          .find(`.single-event:nth-of-type(${i + 1}) li:nth-of-type(2)`)
           .invoke("text")
           .should("contain", test_event.description);
       });
     });
 
-    it("Event Counts", () => {
+    it("Total event counts", () => {
       // TODO: there should be a better way to wait for a React re-render to update the
       // event count, but a manual wait works currently
       cy.wait(100);
@@ -100,7 +128,9 @@ describe("Admin Dashboard", () => {
         .then(function () {
           // Ensure updated event count is 1 greater then initial event count
           expect(this.newEventCount).to.eq(
-            this.initialEventCount + TEST_EVENTS.length
+            this.initialEventCount +
+              SINGULAR_TEST_EVENTS.length +
+              Object.entries(GROUP_EVENT_COUNTS_BY_GROUP_ID).length
           );
         });
     });
@@ -111,7 +141,7 @@ describe("Admin Dashboard", () => {
       before(() => {});
       beforeEach(() => {
         // Add test events
-        addTestEvents(TEST_EVENTS);
+        addTestEvents([...SINGULAR_TEST_EVENTS, ...GROUP_TEST_EVENTS]);
 
         // Reload page and navigate to admin dashboard
         // cy.reload();
@@ -122,32 +152,75 @@ describe("Admin Dashboard", () => {
         aliasHeaderEventCount("initialEventCount");
       });
 
-      it("Event Counts", () => {
-        // TODO: there should be a better way to wait for a React re-render to update the
-        // event count, but a manual wait works currently
-        cy.wait(100);
+      it("Delete singular events", () => {
+        // Delete all singular events by id
+        cy.getAllEvents().then(({ body }) => {
+          body.forEach(event => {
+            if (!event.groupId) {
+              cy.deleteOwnEvent(event._id);
+            }
+          });
+        });
 
-        cy.deleteOwnGroupEvents(TEST_EVENT_AUTHOR, TEST_EVENT_GROUP_ID);
+        cy.visit("/admindashboard");
+        cy.wait(100);
 
         // Create alias for updated event count
         aliasHeaderEventCount("newEventCount");
 
-        cy.visit("/admindashboard");
         cy.get("h1")
           .should("be.visible")
           .should("not.contain", "LOADING")
           .then(function () {
             // Ensure updated event count matches initial count minus deleted events
             expect(this.newEventCount).to.eq(
-              this.initialEventCount - TEST_EVENTS.length
+              this.initialEventCount - SINGULAR_TEST_EVENTS.length
+            );
+          });
+      });
+
+      it("Delete group events", () => {
+        // Delete all group events
+        cy.deleteOwnGroupEvents(TEST_EVENT_AUTHOR, TEST_EVENT_GROUP_ID);
+
+        cy.visit("/admindashboard");
+        cy.wait(100);
+
+        // Create alias for updated event count
+        aliasHeaderEventCount("newEventCount");
+
+        cy.get("h1")
+          .should("be.visible")
+          .should("not.contain", "LOADING")
+          .then(function () {
+            // Ensure updated event count matches initial count minus deleted events
+            expect(this.newEventCount).to.eq(
+              this.initialEventCount -
+                Object.entries(GROUP_EVENT_COUNTS_BY_GROUP_ID).length
             );
           });
       });
 
       it("Event titles and descriptions no longer exist", () => {
+        // Delete all singular events by id
+        cy.getAllEvents().then(({ body }) => {
+          body.forEach(event => {
+            if (!event.groupId) {
+              cy.deleteOwnEvent(event._id);
+            }
+          });
+        });
+
+        // Delete all group events
         cy.deleteOwnGroupEvents(TEST_EVENT_AUTHOR, TEST_EVENT_GROUP_ID);
-        // Ensure all events were deleted
-        cy.get("#events").not("be.visible");
+
+        cy.wait(100);
+
+        // Ensure single events are no longer displayed
+        cy.get("#single-events .single-event").should("not.exist");
+
+        // Ensure group events are no longer displayed
+        cy.get("#group-events .group-event").should("not.exist");
       });
     });
   });

--- a/cypress/e2e/admin-dashboard.cy.js
+++ b/cypress/e2e/admin-dashboard.cy.js
@@ -2,9 +2,10 @@
 
 import tgt from "../support/tgt";
 
-// Generate test event
 const TEST_EVENT_AUTHOR = "100_DEVER";
 const TEST_EVENT_GROUP_ID = "admin_text_event_id";
+
+// Generate singular test events
 const SINGULAR_TEST_EVENTS = [
   {
     title: "1st SINGULAR EVENT",
@@ -24,6 +25,7 @@ const SINGULAR_TEST_EVENTS = [
   },
 ];
 
+// Generate group (recurring) test events
 const GROUP_TEST_EVENTS = [
   {
     title: "1st GROUP EVENT",
@@ -34,15 +36,17 @@ const GROUP_TEST_EVENTS = [
     endAt: Date.now() + 60 * 60,
   },
   {
-    title: "2nd GROUP EVENT",
-    description: "2nd Group Description",
-    location: "2nd Location",
+    title: "1st GROUP EVENT",
+    description: "1st Group Description",
+    location: "1st Location",
     groupId: TEST_EVENT_GROUP_ID,
     startAt: Date.now() + 60 * 60 * 24,
     endAt: Date.now() + 60 * 60 * 24 + 3600,
   },
 ];
 
+// Calculate group event counts (how many times a group event recurs)
+// indexed by its groupId property
 const GROUP_EVENT_COUNTS_BY_GROUP_ID = GROUP_TEST_EVENTS.reduce(
   (acc, event) => {
     acc[event.groupId] = acc[event.groupId] || 0;
@@ -51,13 +55,12 @@ const GROUP_EVENT_COUNTS_BY_GROUP_ID = GROUP_TEST_EVENTS.reduce(
   {}
 );
 
+// Utility function to add test events consistently before each test
 const addTestEvents = test_events => {
   cy.url().then(return_url => {
-    cy.visit("/");
-
     // Generate test events
+    cy.visit("/");
     cy.createOwnEvents(TEST_EVENT_AUTHOR, ...test_events);
-    // TODO add group events
 
     // Close event creation modal
     tgt.modal.close();
@@ -81,62 +84,74 @@ describe("Admin Dashboard", () => {
     cy.get("h1").contains("Admin Dashboard");
   });
 
-  describe("Add events", () => {
-    before(() => {
-      // Navigate to admin dashboard
-      cy.visit("/admindashboard");
-      cy.get("#events").should("exist");
+  describe("Page updates when events change", () => {
+    describe("Add events", () => {
+      before(() => {
+        // Navigate to admin dashboard
+        cy.visit("/admindashboard");
+        cy.get("#events").should("exist");
 
-      // Create alias for initial event count
-      aliasHeaderEventCount("initialEventCount");
-    });
-    beforeEach(() => {
-      // Add test events
-      addTestEvents([...SINGULAR_TEST_EVENTS, ...GROUP_TEST_EVENTS]);
+        // Create alias for initial event count
+        aliasHeaderEventCount("initialEventCount");
+      });
+      beforeEach(() => {
+        // Add test events
+        addTestEvents([...SINGULAR_TEST_EVENTS, ...GROUP_TEST_EVENTS]);
 
-      // Navigate to admin dashboard
-      cy.visit("/admindashboard");
-    });
+        // Navigate to admin dashboard
+        cy.visit("/admindashboard");
+      });
 
-    it("Single event titles and descriptions", () => {
-      SINGULAR_TEST_EVENTS.forEach((test_event, i) => {
-        // Ensure test events rendered with correct title
-        cy.get("#events")
-          .find(`.single-event:nth-of-type(${i + 1}) li:nth-of-type(1)`)
-          .invoke("text")
-          .should("contain", test_event.title);
+      it("Single event titles and descriptions", () => {
+        SINGULAR_TEST_EVENTS.forEach((test_event, i) => {
+          // Ensure test events rendered with correct title
+          cy.get("#events")
+            .find(`.single-event:nth-of-type(${i + 1}) li:nth-of-type(1)`)
+            .invoke("text")
+            .should("contain", test_event.title);
 
-        // Ensure test event rendered with correct description
-        cy.get("#events")
-          .find(`.single-event:nth-of-type(${i + 1}) li:nth-of-type(2)`)
-          .invoke("text")
-          .should("contain", test_event.description);
+          // Ensure test event rendered with correct description
+          cy.get("#events")
+            .find(`.single-event:nth-of-type(${i + 1}) li:nth-of-type(2)`)
+            .invoke("text")
+            .should("contain", test_event.description);
+        });
+      });
+
+      it("Group event titles and descriptions", () => {
+        GROUP_TEST_EVENTS.forEach((test_event, i) => {
+          // Ensure test events rendered with correct title and description
+          cy.get("#events")
+            .find(`.group-event`)
+            .invoke("text")
+            .should("contain", test_event.title)
+            .should("contain", test_event.description);
+        });
+      });
+
+      it("Total event counts", () => {
+        // TODO: there should be a better way to wait for a React re-render to update the
+        // event counts, but a manual wait works currently. This applies to other similar
+        // manual waits in other admin dashboard tests.
+        cy.wait(100);
+
+        // Create alias for updated event count
+        aliasHeaderEventCount("newEventCount");
+
+        cy.get("h1")
+          .should("be.visible")
+          .should("not.contain", "LOADING")
+          .then(function () {
+            // Ensure updated event count is 1 greater then initial event count
+            expect(this.newEventCount).to.eq(
+              this.initialEventCount +
+                SINGULAR_TEST_EVENTS.length +
+                Object.entries(GROUP_EVENT_COUNTS_BY_GROUP_ID).length
+            );
+          });
       });
     });
 
-    it("Total event counts", () => {
-      // TODO: there should be a better way to wait for a React re-render to update the
-      // event count, but a manual wait works currently
-      cy.wait(100);
-
-      // Create alias for updated event count
-      aliasHeaderEventCount("newEventCount");
-
-      cy.get("h1")
-        .should("be.visible")
-        .should("not.contain", "LOADING")
-        .then(function () {
-          // Ensure updated event count is 1 greater then initial event count
-          expect(this.newEventCount).to.eq(
-            this.initialEventCount +
-              SINGULAR_TEST_EVENTS.length +
-              Object.entries(GROUP_EVENT_COUNTS_BY_GROUP_ID).length
-          );
-        });
-    });
-  });
-
-  describe("Page updates when events change", () => {
     describe("Delete Events", () => {
       before(() => {});
       beforeEach(() => {
@@ -144,7 +159,6 @@ describe("Admin Dashboard", () => {
         addTestEvents([...SINGULAR_TEST_EVENTS, ...GROUP_TEST_EVENTS]);
 
         // Reload page and navigate to admin dashboard
-        // cy.reload();
         cy.visit("/admindashboard");
         cy.wait(100);
 

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -42,3 +42,14 @@ Cypress.Commands.add("deleteOwnGroupEvents", (userCode, groupId) => {
 
   cy.reload();
 });
+
+Cypress.Commands.add("deleteOwnEvent", id => {
+  if (id) {
+    cy.request("DELETE", `/events/${id}`);
+  }
+});
+
+Cypress.Commands.add("getAllEvents", userCode => {
+  // cy.login(userCode)
+  return cy.request("GET", "/events");
+});


### PR DESCRIPTION
# Description

Group repeating events with the same `groupId` into a single items on the admin dashboard and split single (non-repeating) events and repeating events into separate sections.

## Type of change

Please select everything applicable. Please, do not delete any lines.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] This change requires an update to testing

## Issue
This PR addresses issue #413 
- [x] Is this related to a specific issue? If so, please specify:

# Checklist:

- [x] This PR is up to date with the main branch, and merge conflicts have been resolved
- [x] I have executed `npm run test` and all tests have passed successfully or I have included details within my PR on the failure.
- [x] I have executed `npm run lint` and resolved any outstanding errors. Most issues can be solved by executing `npm run format`
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
