### PR TITLE
Made the calendar page mobile-responsive

### DIFF
--- a/client/src/features/calendar/MonthAndYear.js
+++ b/client/src/features/calendar/MonthAndYear.js
@@ -11,7 +11,7 @@ const MonthAndYear = ({
       <div className="flex">
         <button onClick={handlePreviousMonth}>
           <svg
-            className="w-6 h-6"
+            className="w-6 h-6 max-[440px]:w-4 max-[440px]:h-4"
             xmlns="http://www.w3.org/2000/svg"
             fill="none"
             viewBox="0 0 24 24"
@@ -27,7 +27,7 @@ const MonthAndYear = ({
         </button>
         <button data-cy="next-month" onClick={handleNextMonth}>
           <svg
-            className="w-6 h-6"
+            className="w-6 h-6 max-[440px]:w-4 max-[440px]:h-4"
             xmlns="http://www.w3.org/2000/svg"
             fill="none"
             viewBox="0 0 24 24"
@@ -42,7 +42,7 @@ const MonthAndYear = ({
           </svg>
         </button>
       </div>
-      <h2 className="ml-2 w-[14ch] text-3xl font-bold leading-none">
+      <h2 className="max-[440px]:ml-1 ml-2 w-[14ch] max-[440px]:text-base max-[440px]:text-center sm:text-3xl text-xl font-bold leading-none">
         {month}, {year}
       </h2>
     </div>

--- a/client/src/features/calendarHeader/CalendarHeader.js
+++ b/client/src/features/calendarHeader/CalendarHeader.js
@@ -30,8 +30,8 @@ function CalendarHeader({ date }) {
   };
 
   return (
-    <header className="flex items-center px-5 py-3 bg-white justify-between">
-      <section className="flex space-x-3">
+    <header className="flex items-center max-[440px]:px-2 px-5 py-3 bg-white lg:justify-between w-full justify-center lg:flex-nowrap flex-wrap  max-[440px]:gap-x-2 gap-x-6 lg:gap-x-4 overflow-hidden">
+      <section className="flex max-[440px]:gap-x-2 gap-x-6 lg:gap-x-4">
         <HeaderButton
           Icon={BsCalendarPlusFill}
           tooltipText="Add Event"
@@ -49,8 +49,8 @@ function CalendarHeader({ date }) {
           onClick={() => navigate("/")}
         />
       </section>
-      <section className="flex items-center space-x-3">
-        <img src={Logo} className="max-w-none" alt="Logo" />
+      <section className="flex items-center w-full order-first lg:w-min lg:space-x-3 lg:order-none justify-between mb-4 lg:mb-0">
+        <img src={Logo} className="max-w-none max-[380px]:w-9" alt="Logo" />
         <MonthAndYear
           month={date?.month}
           year={date?.year}
@@ -63,7 +63,7 @@ function CalendarHeader({ date }) {
           onClick={() => date.getCurrentMonth()}
         />
       </section>
-      <section className="flex space-x-3">
+      <section className="flex max-[440px]:gap-x-2 gap-x-6 lg:gap-x-4">
         <HeaderButton
           Icon={IoChatbubblesOutline}
           tooltipText="Feedback"

--- a/client/src/features/calendarHeader/components/HeaderButton.js
+++ b/client/src/features/calendarHeader/components/HeaderButton.js
@@ -1,11 +1,11 @@
 function HeaderButton({ Icon, tooltipText, ...rest }) {
   return (
     <button
-      className="relative p-3 bg-[#F5E7DE] shadow-[0_4px_4px_0_rgba(0,0,0,0.25)] rounded-lg group font-inconsolata font-bold"
+      className="p-2 sm:p-3 relative bg-[#F5E7DE] shadow-[0_4px_4px_0_rgba(0,0,0,0.25)] rounded-lg group font-inconsolata font-bold"
       {...rest}
     >
-      <Icon className="w-8 h-8 text-[#C57756]" />
-      <span className="absolute -bottom-full left-1/2 -translate-x-1/2 opacity-0 group-hover:opacity-100 transition-opacity duration-200 ease-in bg-[#F5CEB5BF] p-2 border border-black whitespace-nowrap rounded-md pointer-events-none">
+      <Icon className="max-[380px]:w-4 max-[380px]:h-4 w-6 h-6 sm:w-8 sm:h-8 text-[#C57756]" />
+      <span className="absolute -bottom-full left-1/2 -translate-x-1/2 opacity-0 group-hover:opacity-100 transition-opacity duration-200 ease-in bg-[#F5CEB5BF] p-2 border border-black whitespace-nowrap rounded-md pointer-events-none z-10">
         {tooltipText}
       </span>
     </button>

--- a/client/src/features/calendarHeader/components/TodayButton.js
+++ b/client/src/features/calendarHeader/components/TodayButton.js
@@ -1,10 +1,10 @@
 function TodayButton({ text, tooltipText, ...rest }) {
   return (
     <button
-      className="relative p-2 px-4 bg-teal-light shadow-[0_4px_4px_0_rgba(0,0,0,0.25)] rounded-lg font-inconsolata font-bold"
+      className="relative sm:p-2 sm:px-4 p-1 px-3 bg-teal-light shadow-[0_4px_4px_0_rgba(0,0,0,0.25)] rounded-lg font-inconsolata font-bold"
       {...rest}
     >
-      <span className="text-lg font-bold">{text}</span>
+      <span className="text-lg font-bold max-[440px]:text-sm">{text}</span>
       <span className="absolute -bottom-full left-1/2 -translate-x-1/2 translate-y-5 opacity-0 group-hover:opacity-100 transition-opacity duration-200 ease-in bg-teal-light p-2 border border-black whitespace-nowrap rounded-md pointer-events-none">
         {tooltipText}
       </span>


### PR DESCRIPTION
# Description

The calendar page is now mobile-responsive; the issue before this change was that the calendar header was too wide, and was not resizing properly when the screen size changed. Using only Tailwind CSS, this has been fixed. Please see the screenshots below for examples of what the header now looks like at different breakpoints!

![Screenshot 2023-08-28 134434](https://github.com/Together-100Devs/Together/assets/122644200/9fc36cd4-abfc-47a7-bf9b-963adfda1b35)
![Screenshot 2023-08-28 134530](https://github.com/Together-100Devs/Together/assets/122644200/892753c1-11d7-4b58-a122-78c44f55838d)
![Screenshot 2023-08-28 134604](https://github.com/Together-100Devs/Together/assets/122644200/e7774f0f-73c2-4037-94c4-0f7e16af6764)
![Screenshot 2023-08-28 134622](https://github.com/Together-100Devs/Together/assets/122644200/e7bed4b9-e18e-46f2-b359-338ca4a3fe10)
![Screenshot 2023-08-28 134643](https://github.com/Together-100Devs/Together/assets/122644200/d3bd0b80-08e2-4172-9b99-e24694a170cc)


## Type of change

Please select everything applicable. Please, do not delete any lines.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change requires an update to testing

## Issue

- [X] Is this related to a specific issue? If so, please specify:  #449 

# Checklist:

- [X] This PR is up to date with the main branch, and merge conflicts have been resolved
- [X] I have executed `npm run test` and all tests have passed successfully or I have included details within my PR on the failure.
- [X] I have executed `npm run lint` and resolved any outstanding errors. Most issues can be solved by executing `npm run format`
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
