### PR TITLE
chore: remove arrowParens avoid from prettier config

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,6 +1,4 @@
 {
-  "arrowParens": "avoid",
-  "endOfLine": "auto",
   "tabWidth": 2,
   "trailingComma": "es5",
   "bracketSpacing": true

--- a/client/src/contexts/AuthContext/useProvideAuth.js
+++ b/client/src/contexts/AuthContext/useProvideAuth.js
@@ -12,7 +12,7 @@ const useProvideAuth = () => {
   // Check if there is already a user session
   useEffect(() => {
     // If so, save user's information to the context
-    DataService.getCurrentUser().then(response => {
+    DataService.getCurrentUser().then((response) => {
       console.log(response.data);
       setUser(response.data);
     });

--- a/client/src/contexts/EventsContext/useProvideEvents.js
+++ b/client/src/contexts/EventsContext/useProvideEvents.js
@@ -6,7 +6,7 @@ const useProvideEvents = () => {
   // cache to store api call arguments
   const cache = useRef([]);
 
-  const addEvents = newEvents => {
+  const addEvents = (newEvents) => {
     setEvents([...events, ...newEvents]);
   };
 

--- a/client/src/contexts/FormContext/useProvideForm.js
+++ b/client/src/contexts/FormContext/useProvideForm.js
@@ -15,7 +15,7 @@ const useProvideForm = () => {
   const [formCreateEventErrors, setFormCreateEventErrors] = useState([]);
   const [formScheduleEventErrors, setFormScheduleEventErrors] = useState([]);
 
-  const handleNewStep = async direction => {
+  const handleNewStep = async (direction) => {
     const newStep = direction === "next" ? currentStep + 1 : currentStep - 1;
 
     if (newStep > 0 && newStep <= totalSteps.length) {
@@ -41,7 +41,7 @@ const useProvideForm = () => {
 
       const events = response.data.events;
       addEvents(
-        events.filter(e => {
+        events.filter((e) => {
           const s = new Date(e.startAt);
           const month = s.getMonth();
           const year = s.getFullYear();

--- a/client/src/contexts/FormModalContext/useProvideFormModal.js
+++ b/client/src/contexts/FormModalContext/useProvideFormModal.js
@@ -14,7 +14,7 @@ const useProvideFormModal = () => {
   };
 
   const handleToggle = () => {
-    setIsOpen(prevState => !prevState);
+    setIsOpen((prevState) => !prevState);
   };
 
   return {

--- a/client/src/contexts/ModalContext/useProvideModal.js
+++ b/client/src/contexts/ModalContext/useProvideModal.js
@@ -15,7 +15,7 @@ const useProvideModal = () => {
   };
 
   const handleToggle = () => {
-    setIsOpen(prevState => !prevState);
+    setIsOpen((prevState) => !prevState);
   };
 
   return {

--- a/client/src/features/calendar/Calendar.js
+++ b/client/src/features/calendar/Calendar.js
@@ -56,11 +56,11 @@ const Calendar = ({ date }) => {
       setStatus(Status.LOADING);
       cache.current.push(date.monthStart);
       fetch()
-        .then(data => {
-          setEvents(prev => [...prev, ...data]);
+        .then((data) => {
+          setEvents((prev) => [...prev, ...data]);
           setStatus(Status.RESOLVED);
         })
-        .catch(error => {
+        .catch((error) => {
           setError(error.message);
           setStatus(Status.REJECTED);
         });

--- a/client/src/features/calendar/DayCard.js
+++ b/client/src/features/calendar/DayCard.js
@@ -53,7 +53,7 @@ const DayCard = ({ date, events }) => {
             let chosenDate = `${date.getFullYear()}-${(date.getMonth() + 1)
               .toString()
               .padStart(2, "0")}-${date.getDate().toString().padStart(2, "0")}`;
-            setFormData(prevFormData => ({
+            setFormData((prevFormData) => ({
               ...prevFormData,
               initialDate: chosenDate,
               finalDate: chosenDate,

--- a/client/src/features/calendar/DayCardList.js
+++ b/client/src/features/calendar/DayCardList.js
@@ -27,11 +27,11 @@ const DayCardList = ({ data, firstDayOfMonth }) => {
       className={`grid flex-grow w-full h-auto grid-cols-7 grid-rows-${numRows} gap-px pt-px mt-1 bg-gray-200`}
     >
       {/* Empty div used for days that are not in the month */}
-      {daysFromPrevMonth.map(day => (
+      {daysFromPrevMonth.map((day) => (
         <div key={`day-${day}`}></div>
       ))}
 
-      {data.map(dayData => (
+      {data.map((dayData) => (
         <DayCard key={dayData.date} {...dayData} />
       ))}
     </div>

--- a/client/src/features/calendar/Event.js
+++ b/client/src/features/calendar/Event.js
@@ -2,7 +2,7 @@ import React from "react";
 import { formatToLocalTime } from "utilities/calendar";
 import { useModalContext } from "contexts/ModalContext";
 
-const Event = props => {
+const Event = (props) => {
   const modal = useModalContext();
   const confirmedCss = "bg-gray-500";
   const unconfirmedCSss = "border border-gray-500";

--- a/client/src/features/calendarHeader/CalendarHeader.js
+++ b/client/src/features/calendarHeader/CalendarHeader.js
@@ -21,7 +21,7 @@ function CalendarHeader({ date }) {
 
   const GH_ISSUES_URL = "https://github.com/Caleb-Cohen/Together/issues";
 
-  const linkToUrl = url => {
+  const linkToUrl = (url) => {
     window.open(url, "_blank");
   };
 

--- a/client/src/features/form/FormCreateEvent.js
+++ b/client/src/features/form/FormCreateEvent.js
@@ -7,10 +7,10 @@ export default function FormCreateEvent() {
   const { formData, setFormData, formCreateEventErrors } = useFormContext();
 
   // This updates the form data's in the context
-  const handleChange = e => {
+  const handleChange = (e) => {
     const { name, value } = e.target;
 
-    setFormData(prevFormData => ({
+    setFormData((prevFormData) => ({
       ...prevFormData,
       [name]: value,
       discordName: auth.user?.displayName,

--- a/client/src/features/form/FormMover.js
+++ b/client/src/features/form/FormMover.js
@@ -44,7 +44,7 @@ const FormMover = () => {
     const updateStepStatus = () => {
       const stepNumber = currentStep - 1;
       // Update newStep object's status
-      setNewStep(prevNewStep =>
+      setNewStep((prevNewStep) =>
         prevNewStep.map((stepObject, count) => {
           // Current step
           if (count === stepNumber) {

--- a/client/src/features/form/FormRecurringDates.js
+++ b/client/src/features/form/FormRecurringDates.js
@@ -18,12 +18,12 @@ export default function FormRecurringDates() {
   }, [formData.recurring, formData.recurring.rate]);
 
   // This handles the value change when a recurrence rate checkbox is selected
-  const handleDaysOfWeekChange = e => {
+  const handleDaysOfWeekChange = (e) => {
     const { value } = e.target;
 
     //if day is already checked, uncheck it
     if (formData.recurring.days.includes(value)) {
-      formData.recurring.days = formData.recurring.days.filter(day => {
+      formData.recurring.days = formData.recurring.days.filter((day) => {
         return day !== value;
       });
     } else {
@@ -34,7 +34,7 @@ export default function FormRecurringDates() {
   };
 
   // This handles the value change when a day of the week for a weekly recurring event is selected
-  const handleRateChange = e => {
+  const handleRateChange = (e) => {
     const { name } = e.target;
 
     // Handle the rates of occurunces

--- a/client/src/features/form/FormScheduleEvent.js
+++ b/client/src/features/form/FormScheduleEvent.js
@@ -7,12 +7,12 @@ import { format } from "date-fns";
 export default function FormScheduleEvent() {
   const { formData, setFormData, formScheduleEventErrors } = useFormContext();
 
-  const handleChange = e => {
+  const handleChange = (e) => {
     const { name, value } = e.target;
 
     // Set the value of the end date equal to start date's value when the start date's value is change, but NOT vice versa.
     if (name === "initialDate" && formData.recurring.rate === "noRecurr") {
-      setFormData(prevFormData => ({
+      setFormData((prevFormData) => ({
         ...prevFormData,
         initialDate: value,
         finalDate: value,
@@ -20,7 +20,7 @@ export default function FormScheduleEvent() {
       return;
     }
 
-    setFormData(prevFormData => ({ ...prevFormData, [name]: value }));
+    setFormData((prevFormData) => ({ ...prevFormData, [name]: value }));
   };
 
   return (

--- a/client/src/features/form/UserForm.js
+++ b/client/src/features/form/UserForm.js
@@ -15,7 +15,7 @@ const UserForm = () => {
   const modal = useFormModalContext();
 
   // Called to display different parts of the form based on the latest step.
-  const displayStep = step => {
+  const displayStep = (step) => {
     switch (step) {
       case 1:
         // Fields: Title, Description, Start Date, Final Date, Discord Username

--- a/client/src/features/home/HamburgerNav.js
+++ b/client/src/features/home/HamburgerNav.js
@@ -38,7 +38,7 @@ function HamburgerNav({ logo, logotext }) {
             open ? "top-20" : "top-[-480px]"
           }`}
         >
-          {Links.map(Link => {
+          {Links.map((Link) => {
             return (
               <li key={Link.name} className="text-xl my-7">
                 {Link.type === "button" && (

--- a/client/src/features/modal/EventModal.jsx
+++ b/client/src/features/modal/EventModal.jsx
@@ -37,8 +37,8 @@ const EventModal = () => {
               .then(
                 // eslint-disable-next-line
                 () =>
-                  setEvents(prev =>
-                    prev.filter(el => el._id !== modal.activeEvent._id)
+                  setEvents((prev) =>
+                    prev.filter((el) => el._id !== modal.activeEvent._id)
                   )
               )
           }
@@ -56,8 +56,10 @@ const EventModal = () => {
               .then(
                 // eslint-disable-next-line
                 () =>
-                  setEvents(prev =>
-                    prev.filter(el => el.groupId !== modal.activeEvent.groupId)
+                  setEvents((prev) =>
+                    prev.filter(
+                      (el) => el.groupId !== modal.activeEvent.groupId
+                    )
                   )
               )
           }

--- a/client/src/features/modal/Modal.jsx
+++ b/client/src/features/modal/Modal.jsx
@@ -35,7 +35,7 @@ const Modal = ({ children, context }) => {
           <Backdrop onClick={context.handleClose}>
             <motion.div
               className="modal overflow-y-auto"
-              onClick={e => e.stopPropagation()}
+              onClick={(e) => e.stopPropagation()}
               variants={dropIn}
               initial="hidden"
               animate="visible"

--- a/client/src/hooks/useDate.js
+++ b/client/src/hooks/useDate.js
@@ -19,11 +19,11 @@ const useDate = () => {
   const firstDay = format(startOfMonth(date), "E");
 
   const getNextMonth = () => {
-    setDate(prevDate => new Date(getYear(prevDate), getMonth(prevDate) + 1));
+    setDate((prevDate) => new Date(getYear(prevDate), getMonth(prevDate) + 1));
   };
 
   const getPreviousMonth = () => {
-    setDate(prevDate => new Date(getYear(prevDate), getMonth(prevDate) - 1));
+    setDate((prevDate) => new Date(getYear(prevDate), getMonth(prevDate) - 1));
   };
   const getCurrentMonth = () => {
     setDate(() => new Date());

--- a/client/src/pages/AdminDashboard.js
+++ b/client/src/pages/AdminDashboard.js
@@ -15,7 +15,7 @@ export const AdminDashboard = () => {
     const response = await DataService.getAll();
 
     // Filter only single events
-    setSingleEvents(response.data.filter(e => e.groupId === null));
+    setSingleEvents(response.data.filter((e) => e.groupId === null));
 
     // Group remaining events by groupId
     let gEvents = response.data.reduce((map, event) => {
@@ -76,7 +76,7 @@ export const AdminDashboard = () => {
         <section id="single-events">
           {/* Display all events in an unordered list when the data is finished loading */}
           {loading ||
-            Object.keys(singleEvents).map(key => {
+            Object.keys(singleEvents).map((key) => {
               return (
                 <EventCard
                   key={singleEvents[key]._id}
@@ -92,7 +92,7 @@ export const AdminDashboard = () => {
           </h2>
           <hr />
           {loading ||
-            Object.keys(groupEvents).map(key => {
+            Object.keys(groupEvents).map((key) => {
               return (
                 <GroupEventCard
                   key={groupEvents[key]._id}

--- a/client/src/pages/CalendarPage.js
+++ b/client/src/pages/CalendarPage.js
@@ -18,7 +18,7 @@ function CalendarPage() {
   const modal = useModalContext();
   const canScrollMonthRef = useRef(true);
 
-  const handleWheelScroll = e => {
+  const handleWheelScroll = (e) => {
     if (!canScrollMonthRef.current) return;
     canScrollMonthRef.current = false;
 

--- a/client/src/test/events.js
+++ b/client/src/test/events.js
@@ -7,7 +7,7 @@ const get = async () => {
 };
 
 // Post request
-const create = async userData => {
+const create = async (userData) => {
   const response = await axios.post("/events", userData);
   return response.data;
 };
@@ -19,7 +19,7 @@ const update = async (id, newUserData) => {
 };
 
 // Delete request
-const remove = async id => {
+const remove = async (id) => {
   try {
     const response = await axios.delete(`/events/${id}/`);
     return response.data;

--- a/client/src/utilities/calendar.js
+++ b/client/src/utilities/calendar.js
@@ -3,7 +3,7 @@ import { parseISO, format } from "date-fns";
 export const getMatchMonthAndYear = (monthToMatch, yearToMatch, events) => {
   if (!events.length) return [];
 
-  const allMatchedEvents = events.filter(event => {
+  const allMatchedEvents = events.filter((event) => {
     const isoDate = parseISO(event.startAt);
     const monthInString = format(isoDate, "LLLL"); // December
     const year = isoDate.getFullYear();
@@ -15,14 +15,14 @@ export const getMatchMonthAndYear = (monthToMatch, yearToMatch, events) => {
 export const getEventsByDayNumber = (currentDay, allEvents) => {
   if (!allEvents.length) return [];
 
-  return allEvents.filter(event => {
+  return allEvents.filter((event) => {
     const isoDate = parseISO(event.startAt);
     const day = format(isoDate, "d"); // '2'
     return currentDay === Number(day);
   });
 };
 
-export const formatToLocalTime = date => {
+export const formatToLocalTime = (date) => {
   const isoDate = parseISO(date);
   return format(isoDate, "p");
 };

--- a/cypress.config.js
+++ b/cypress.config.js
@@ -12,7 +12,7 @@ module.exports = defineConfig({
       on("task", {
         clearDatabase() {
           require("dotenv").config({ path: "./server/config/.env" });
-          return require("./server/config/database")().then(async conn => {
+          return require("./server/config/database")().then(async (conn) => {
             for (const { name } of await conn.connection.db
               .listCollections()
               .toArray()) {

--- a/cypress/e2e/admin-dashboard.cy.js
+++ b/cypress/e2e/admin-dashboard.cy.js
@@ -56,8 +56,8 @@ const GROUP_EVENT_COUNTS_BY_GROUP_ID = GROUP_TEST_EVENTS.reduce(
 );
 
 // Utility function to add test events consistently before each test
-const addTestEvents = test_events => {
-  cy.url().then(return_url => {
+const addTestEvents = (test_events) => {
+  cy.url().then((return_url) => {
     // Generate test events
     cy.visit("/");
     cy.createOwnEvents(TEST_EVENT_AUTHOR, ...test_events);
@@ -71,7 +71,7 @@ const addTestEvents = test_events => {
 };
 
 describe("Admin Dashboard", () => {
-  const aliasHeaderEventCount = alias_name => {
+  const aliasHeaderEventCount = (alias_name) => {
     cy.get("h1 .event-count")
       .invoke("text")
       .should("not.contain", "LOADING")
@@ -119,7 +119,7 @@ describe("Admin Dashboard", () => {
       });
 
       it("Group event titles and descriptions", () => {
-        GROUP_TEST_EVENTS.forEach(test_event => {
+        GROUP_TEST_EVENTS.forEach((test_event) => {
           // Ensure test events rendered with correct title and description
           cy.get("#events")
             .find(`.group-event`)
@@ -169,7 +169,7 @@ describe("Admin Dashboard", () => {
       it("Delete singular events", () => {
         // Delete all singular events by id
         cy.getAllEvents().then(({ body }) => {
-          body.forEach(event => {
+          body.forEach((event) => {
             if (!event.groupId) {
               cy.deleteOwnEvent(event._id);
             }
@@ -218,7 +218,7 @@ describe("Admin Dashboard", () => {
       it("Event titles and descriptions no longer exist", () => {
         // Delete all singular events by id
         cy.getAllEvents().then(({ body }) => {
-          body.forEach(event => {
+          body.forEach((event) => {
             if (!event.groupId) {
               cy.deleteOwnEvent(event._id);
             }

--- a/cypress/e2e/create-event-form.cy.js
+++ b/cypress/e2e/create-event-form.cy.js
@@ -9,7 +9,7 @@ import {
 import tgt from "../support/tgt";
 
 describe("Event Creation Form", () => {
-  const dayCheckboxesExist = should => {
+  const dayCheckboxesExist = (should) => {
     for (const day of [
       "Monday",
       "Tuesday",
@@ -35,7 +35,7 @@ describe("Event Creation Form", () => {
 
     tgt.createForm
       .alerts()
-      .each($alert => {
+      .each(($alert) => {
         const text = $alert.text().split("Error: ")[1];
         console.log("expectingErrors", expectingErrors);
         expect(expectingErrors).to.include(text);
@@ -71,7 +71,7 @@ describe("Event Creation Form", () => {
     cy.get('input[name="discordName"]')
       .should("have.value", "100Dever#0001")
       .should("be.disabled");
-    cy.contains("button", "Back").then($button =>
+    cy.contains("button", "Back").then(($button) =>
       expect($button.css("cursor")).to.equal("not-allowed")
     );
     tgt.createForm.button.next().click();

--- a/cypress/e2e/view-event-modal.cy.js
+++ b/cypress/e2e/view-event-modal.cy.js
@@ -17,7 +17,7 @@ describe("View Event Modal", () => {
         const overmorrow = createOffsetDate(tomorrow, "Date", 1);
         const overmorrowAndAnHour = createOffsetDate(overmorrow, "Hours", 1);
 
-        cy.task("generateObjectId").then(groupId =>
+        cy.task("generateObjectId").then((groupId) =>
           cy.createOwnEvents(
             "100_DEVER",
             ...[
@@ -29,7 +29,7 @@ describe("View Event Modal", () => {
                 startAt: overmorrow,
                 endAt: overmorrowAndAnHour,
               },
-            ].map(info => ({
+            ].map((info) => ({
               ...info,
               title: "Test Title",
               description: "Test Description",
@@ -111,7 +111,7 @@ describe("View Event Modal", () => {
       1
     );
 
-    cy.task("generateObjectId").then(groupId =>
+    cy.task("generateObjectId").then((groupId) =>
       cy.createOwnEvents(
         "100_DEVER",
         ...[
@@ -145,7 +145,7 @@ describe("View Event Modal", () => {
             endAt: tomorrowAndAnHour,
             groupId: null,
           },
-        ].map(info => ({
+        ].map((info) => ({
           ...info,
           description: "Test Description",
           location: "Test Location",

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -11,7 +11,7 @@ Cypress.Commands.add(
         url: "https://discord.com/oauth2/authorize*",
         times: 1,
       },
-      req =>
+      (req) =>
         req.redirect(
           Cypress.config().baseUrl + "/auth/discord/callback?code=" + userCode
         )
@@ -43,7 +43,7 @@ Cypress.Commands.add("deleteOwnGroupEvents", (userCode, groupId) => {
   cy.reload();
 });
 
-Cypress.Commands.add("deleteOwnEvent", id => {
+Cypress.Commands.add("deleteOwnEvent", (id) => {
   if (id) {
     cy.request("DELETE", `/events/${id}`);
   }

--- a/cypress/support/functions.js
+++ b/cypress/support/functions.js
@@ -22,7 +22,7 @@ export const getMonthAndYear = (date = new Date()) => {
   })}, ${date.getFullYear()}`;
 };
 
-export const getHoursAndMinutes = date => {
+export const getHoursAndMinutes = (date) => {
   return date
     .toLocaleString("default", {
       hour: "numeric",
@@ -37,14 +37,14 @@ export const createOffsetDate = (date, what, amount) => {
   return newDate;
 };
 
-export const dateToHHMM = date => {
+export const dateToHHMM = (date) => {
   return `${date.getHours().toString().padStart(2, "0")}:${date
     .getMinutes()
     .toString()
     .padStart(2, "0")}`;
 };
 
-export const dateToYYYYMMDD = date => {
+export const dateToYYYYMMDD = (date) => {
   return `${date.getFullYear()}-${(date.getMonth() + 1)
     .toString()
     .padStart(2, "0")}-${date.getDate().toString().padStart(2, "0")}`;

--- a/cypress/support/tgt.js
+++ b/cypress/support/tgt.js
@@ -25,8 +25,9 @@ export default {
   modal,
   auth: {
     button: {
-      logout: text => cy.contains("button", text ?? /Logout|Log Out/),
-      login: text => cy.contains("button", text ?? /Login with Discord|Log In/),
+      logout: (text) => cy.contains("button", text ?? /Logout|Log Out/),
+      login: (text) =>
+        cy.contains("button", text ?? /Login with Discord|Log In/),
     },
   },
   calendar: {

--- a/server/config/passport.js
+++ b/server/config/passport.js
@@ -32,7 +32,7 @@ module.exports = function (passport) {
             ? `${profile.username}#${profile.discriminator}`
             : profile.username;
         const is100Dever = profile.guilds.some(
-          server => server.id === "735923219315425401"
+          (server) => server.id === "735923219315425401"
         );
 
         if (!is100Dever) {

--- a/server/controllers/events.js
+++ b/server/controllers/events.js
@@ -13,12 +13,12 @@ module.exports = {
       throw httpError(400);
     }
 
-    events.forEach(e => (e.user = req.user._id));
+    events.forEach((e) => (e.user = req.user._id));
 
     // insertMany result doesn't populate user display name
     const result = await Event.insertMany(events);
     // find newly added events and populate user with displayName
-    const ids = result.map(e => e._id);
+    const ids = result.map((e) => e._id);
     const addedEvents = await Event.find({ _id: { $in: ids } })
       .populate("user", "displayName")
       .lean()

--- a/server/middleware/validateBody.js
+++ b/server/middleware/validateBody.js
@@ -1,6 +1,6 @@
 const httpError = require("../utilities/httpError");
 
-const validateBody = schema => {
+const validateBody = (schema) => {
   const func = (req, _, next) => {
     const formData = req.body;
     const { error } = schema.validate(formData);

--- a/server/routes/main.js
+++ b/server/routes/main.js
@@ -12,7 +12,7 @@ router.get("/auth/logout", (req, res) => {
     /* istanbul ignore next  */
     if (process.env.NODE_ENV !== "test") console.log("User has logged out.");
   });
-  req.session.destroy(err => {
+  req.session.destroy((err) => {
     /* istanbul ignore next  */
     if (err && process.env.NODE_ENV !== "test")
       console.log("Error : Failed to destroy the session during logout.", err);

--- a/server/test/unit/createEventsArrayMockData.js
+++ b/server/test/unit/createEventsArrayMockData.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const generateTestCases = obj => {
+const generateTestCases = (obj) => {
   const arrOfTests = [];
   for (const time of obj.times()) {
     const description = `${obj.dates} ${time[0][0]} - ${time[0][1]}`;
@@ -19,7 +19,7 @@ const generateTestCases = obj => {
         endTime: time[0][1],
         timeZone: obj.timeZone,
       },
-      output: time.map(e => ({
+      output: time.map((e) => ({
         title: "test",
         description: "test",
         location: "test",

--- a/server/test/unit/validateBody.test.js
+++ b/server/test/unit/validateBody.test.js
@@ -8,7 +8,7 @@ const {
 } = require("../../models/Event");
 const sample = require("./validateBodyMockData");
 
-const mockRequest = body => ({ body });
+const mockRequest = (body) => ({ body });
 const mockNext = () => jest.fn();
 
 describe("validateBody", () => {

--- a/server/test/unit/validateObjectId.test.js
+++ b/server/test/unit/validateObjectId.test.js
@@ -1,7 +1,7 @@
 const validateObjectId = require("../../middleware/validateObjectId");
 
 // Request is an object that contains 'params' object
-const mockRequest = params => ({ params });
+const mockRequest = (params) => ({ params });
 // const mockResponse = () => {
 //   const res = {};
 //   res.status = jest.fn().mockReturnValue(res);

--- a/server/utilities/createEventsArray.js
+++ b/server/utilities/createEventsArray.js
@@ -84,7 +84,7 @@ const createEventsArray = ({
   const groupId = rate === "noRecurr" ? null : nanoid();
 
   // Create dates array with events information
-  const events = eventStartDates.map(date => {
+  const events = eventStartDates.map((date) => {
     const startAt = date.epochMilliseconds;
     const endAt = date.add(duration).epochMilliseconds;
     return { title, description, location, groupId, startAt, endAt, rsvp: [] };


### PR DESCRIPTION
# Description

The current setup `"arrowParens": "avoid"` is prone to a lot of changes due to code evolving, and more cognitive load of finding the params.

Described better by Kent C Dodds himself [here](https://github.com/epicweb-dev/config/blob/main/docs/decisions/006-arrow-parens.md).

Also removed the `"endOfLine": "auto"` which is not the current default.

[Docs for arrowParens](https://prettier.io/docs/options#arrow-function-parentheses)
[Docs for endOfLine](https://prettier.io/docs/options#end-of-line)

Note that this PR changes the presets to the default values (most of the time is a better choice).

## Type of change

Please select everything applicable. Please, do not delete any lines.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change requires an update to testing
- [x] Formatting

## Issue

- [ ] Is this related to a specific issue? If so, please specify:

# Checklist:

- [x] This PR is up to date with the main branch, and merge conflicts have been resolved
- [ ] I have executed `npm run test` and all tests have passed successfully or I have included details within my PR on the failure.
- [ ] I have executed `npm run lint` and resolved any outstanding errors. Most issues can be solved by executing `npm run format`
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
