### PR TITLE
Scroll sensitivity fix for months in calendar

### DIFF
--- a/client/src/pages/CalendarPage.jsx
+++ b/client/src/pages/CalendarPage.jsx
@@ -17,9 +17,11 @@ function CalendarPage() {
   const formModal = useFormModalContext();
   const modal = useModalContext();
   const canScrollMonthRef = useRef(true);
+  const scrollEndTimeoutRef = useRef(null);
 
   const handleWheelScroll = (e) => {
     if (!canScrollMonthRef.current) return;
+
     canScrollMonthRef.current = false;
 
     if (e.deltaY > 0) {
@@ -27,9 +29,14 @@ function CalendarPage() {
     } else {
       date.getPreviousMonth();
     }
-    setTimeout(() => {
+
+    if (scrollEndTimeoutRef.current) {
+      clearTimeout(scrollEndTimeoutRef.current);
+    }
+
+    scrollEndTimeoutRef.current = setTimeout(() => {
       canScrollMonthRef.current = true;
-    }, 200);
+    }, 800);
   };
 
   return (

--- a/client/src/pages/CalendarPage.jsx
+++ b/client/src/pages/CalendarPage.jsx
@@ -22,6 +22,7 @@ function CalendarPage() {
   const handleWheelScroll = (e) => {
     if (!canScrollMonthRef.current) return;
 
+    // Immediately lock further scrolling to prevent multiple month changes
     canScrollMonthRef.current = false;
 
     if (e.deltaY > 0) {
@@ -30,10 +31,12 @@ function CalendarPage() {
       date.getPreviousMonth();
     }
 
+    // This ensures we only have one active timeout at any time
     if (scrollEndTimeoutRef.current) {
       clearTimeout(scrollEndTimeoutRef.current);
     }
 
+    // This creates a "cooldown" period between scroll actions
     scrollEndTimeoutRef.current = setTimeout(() => {
       canScrollMonthRef.current = true;
     }, 800);


### PR DESCRIPTION
  # Description

### **Issue Summary**  
**Problem:**  
- Mouse/trackpad wheel scrolls were triggering **4-5 month changes at once** instead of one per scroll.  


**Root Cause:**  
- High-frequency wheel events (common on trackpads) bypassed the scroll lock.  


**Solution:**  
1. **Strict 1-month-per-scroll**:  
   - Throttled wheel events with an **800ms delay** (`setTimeout`).  
   - Used  `passive: false` to block native scroll.  


**Result:**  
- Predictable 1-month navigation per wheel spin.  

## Type of change

Please select everything applicable. Please, do not delete any lines.

- [x] Prevents multiple month changes during a single wheel scroll (now strictly 1 month per wheel release).


## Issue

- [x] Fixes erratic month scrolling and unwanted scrollbars.

# Checklist:

- [x] This PR is up to date with the main branch, and merge conflicts have been resolved
- [x] I have executed `npm run test` and all tests have passed successfully or I have included details within my PR on the failure.
- [x] I have executed `npm run lint` and resolved any outstanding errors. Most issues can be solved by executing `npm run format`
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
