### PR TITLE
fix: remove spaces in .env.example keys

### DIFF
--- a/server/config/.env.example
+++ b/server/config/.env.example
@@ -1,10 +1,10 @@
 # Please copy and paste this template into a new .env file instead of removing .example from the file name
 # Do not change PORT or OAUTH_REDIRECT_URL
 # DB_STRING will create a MongoDB instance on your computer but can be changed to a mongodb.com cluster
-PORT = 2121
-DB_STRING = mongodb://127.0.0.1:27017/
-DISCORD_CLIENT_ID = 1039303417199345684
-DISCORD_CLIENT_SECRET = DISCORD_CLIENT_SECRET
-OAUTH_REDIRECT_URL = http://localhost:3000/
+PORT=2121
+DB_STRING=mongodb://127.0.0.1:27017/
+DISCORD_CLIENT_ID=1039303417199345684
+DISCORD_CLIENT_SECRET=DISCORD_CLIENT_SECRET
+OAUTH_REDIRECT_URL=http://localhost:3000/
 MOCK_USER=true
 NODE_ENV=development


### PR DESCRIPTION
This PR addresses the formatting of environment variables in the .env.example file.
Specifically, it removes unnecessary spaces between keys and values.

✅ Changes Made:
Updated lines like:

From: 
DISCORD_CLIENT_SECRET = DISCORD_CLIENT_SECRET

To:
DISCORD_CLIENT_SECRET=DISCORD_CLIENT_SECRET

📌 Reason
Consistency in .env files is important for proper parsing by environment loaders (like dotenv), and removing extra spaces ensures compatibility across different setups.