### PR TITLE
test: fix missing env variable for backend test

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "start": "npm run client:build && npm run server:start",
     "start-client": "cd client && npm start",
     "test": "concurrently \"npm:test:backend\" \"npm:test:frontend\"",
-    "test:backend": "cross-env MOCK_USER=true jest --coverage --coverage-reporters=\"json\" && mkdir -p .nyc_output && mv coverage/coverage-final.json .nyc_output/coverage-final.json",
+    "test:backend": "cross-env MOCK_USER=true DISCORD_CLIENT_ID=1 jest --coverage --coverage-reporters=\"json\" && mkdir -p .nyc_output && mv coverage/coverage-final.json .nyc_output/coverage-final.json",
     "test:e2e": "cross-env MOCK_USER=false NODE_ENV=test DB_STRING=mongodb://127.0.0.1:27017/ DISCORD_CLIENT_ID=1 DISCORD_CLIENT_SECRET=1 concurrently --success command-cypress --kill-others --names client,mongodb,server,cypress \"npm:client:start\" \"npm:server:dev:mongo\" \"wait-on http-get://localhost:27017/ && npm run --workspace=server start:coverage\" \"wait-on http://localhost:3000 && cypress run\"",
     "test:e2e:dev": "cross-env MOCK_USER=false NODE_ENV=test DB_STRING=mongodb://127.0.0.1:27017/ DISCORD_CLIENT_ID=1 DISCORD_CLIENT_SECRET=1 concurrently --success command-cypress --kill-others --names client,mongodb,server,cypress \"npm:client:start\" \"npm:server:dev:mongo\" \"wait-on http-get://localhost:27017/ && npm run --workspace=server start:coverage\" \"wait-on http://localhost:3000 && cypress open\"",
     "test:frontend": "echo \"No tests yet\" && exit 0"


### PR DESCRIPTION
# Description

Currently the backend tests do not work locally:
```
 FAIL  server/test/acceptance/routes.test.js
  ● Test suite failed to run

    TypeError: OAuth2Strategy requires a clientID option

      17 |   //Discord authentication
      18 |   passport.use(
    > 19 |     new DiscordStrategy(
         |     ^
      20 |       {
      21 |         //Get client ID and Secret from discord developer portal
      22 |         clientID: process.env.DISCORD_CLIENT_ID,
```

## Type of change

Please select everything applicable. Please, do not delete any lines.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change requires an update to testing

## Issue

- [ ] Is this related to a specific issue? If so, please specify:

# Checklist:

- [ ] This PR is up to date with the main branch, and merge conflicts have been resolved
- [ ] I have executed `npm run test` and `npm run test:e2e` and all tests have passed successfully or I have included details within my PR on the failure.
- [ ] I have executed `npm run lint` and resolved any outstanding errors. Most issues can be solved by executing `npm run format`
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
