### PR TITLE
issue#550 | In mobile, the Title and Time of the task were not showing properly for mobile devices

### DIFF
--- a/client/src/features/calendar/Event.jsx
+++ b/client/src/features/calendar/Event.jsx
@@ -1,5 +1,5 @@
-import { formatToLocalTime } from "../../utilities/calendar";
 import { useModalContext } from "../../contexts/ModalContext";
+import { formatToLocalTime } from "../../utilities/calendar";
 
 const Event = (props) => {
   const modal = useModalContext();
@@ -12,17 +12,17 @@ const Event = (props) => {
         modal.handleOpen();
       }}
       key={props.event.title}
-      className="flex items-center shrink-0 h-5 px-1 text-sm hover:bg-gray-200"
+      className="flex items-center truncate text-clip md:text-ellipsis shrink-0 h-5 px-1 text-sm hover:bg-gray-200 cursor-pointer"
     >
       <span
         className={`shrink-0 w-2 h-2 ${
           props.event.confirmed ? confirmedCss : unconfirmedCSss
-        } rounded-full`}
+        } rounded-full hidden md:inline`}
       ></span>
-      <span className="ml-2 text-xs font-light leading-none whitespace-nowrap">
+      <span className="ml-2 text-xs font-light leading-none whitespace-nowrap hidden md:inline">
         {formatToLocalTime(props.event.startAt)}
       </span>
-      <span className="ml-2 font-medium leading-none truncate">
+      <span className="md:ml-2 font-medium leading-none md:truncate ">
         {props.event.title}
       </span>
     </button>


### PR DESCRIPTION
# Description

 In mobile, the Title and Time of the task were not showing properly for mobile devices, | Fixed that by updating classes according to mobile devices

## Type of change

UI Changes, Added Tailwind Classes according to mobile devices, Added md: that means after 768px, those classes will work

Please select everything applicable. Please, do not delete any lines.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change requires an update to testing

## Issue

- [X] Is this related to a specific issue? If so, please specify:  https://github.com/Together-100Devs/Together/issues/550

# Checklist:

- [X] This PR is up to date with the main branch, and merge conflicts have been resolved
- [X] I have executed `npm run test` and `npm run test:e2e` and all tests have passed successfully or I have included details within my PR on the failure.
- [X] I have executed `npm run lint` and resolved any outstanding errors. Most issues can be solved by executing `npm run format`
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
