### PR TITLE
#593 issue: centered MonthAndYeart component

### DIFF
--- a/client/src/features/calendar/MonthAndYear.jsx
+++ b/client/src/features/calendar/MonthAndYear.jsx
@@ -40,7 +40,7 @@ const MonthAndYear = ({
           </svg>
         </button>
       </div>
-      <h2 className="max-[440px]:ml-1 ml-2 w-[14ch] max-[440px]:text-base max-[440px]:text-center sm:text-3xl text-xl font-bold leading-none">
+      <h2 className="max-[440px]:ml-1 ml-2 w-[14ch] max-[440px]:text-base  sm:text-3xl text-xl font-bold leading-none text-center">
         {month}, {year}
       </h2>
     </div>


### PR DESCRIPTION
# Description

It was previously centered only on small devices. I removed the media query and added text-center to make it centered across all screen sizes 

It was: 
<img width="1423" height="362" alt="image" src="https://github.com/user-attachments/assets/607d0434-f04e-4db6-a87a-8097fd290e01" />

Now:
<img width="1573" height="156" alt="image" src="https://github.com/user-attachments/assets/f196cf8f-9133-424f-a207-4549d48fea79" />


## Type of change

Please select everything applicable. Please, do not delete any lines.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change requires an update to testing

## Issue

- [x] Is this related to a specific issue? If so, please specify:

Related to 
https://github.com/Together-100Devs/Together/issues/593

# Checklist:

- [x] This PR is up to date with the main branch, and merge conflicts have been resolved
- [x] I have executed `npm run test` and `npm run test:e2e` and all tests have passed successfully or I have included details within my PR on the failure.
- [x] I have executed `npm run lint` and resolved any outstanding errors. Most issues can be solved by executing `npm run format`
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
