### PR TITLE
Move PR template to .github and add issue keyword to auto-close issue…

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,10 @@
+
 # Description
 
-Moved the pull request template file to the `.github` folder and added a line for automatic issue linking (`Resolves #[issue]`). This change helps contributors properly link their PRs to issues and improves GitHub automation.
+Moved the pull request template file from `docs/pull_request_template.md` to `.github/pull_request_template.md`.  
+Additionally, updated the template content to include a proper issue reference using the `Resolves #[issue]` keyword, which enables automatic issue closing by GitHub when the PR is merged.
+
+This improves contributor guidance and ensures better integration with GitHub’s automation for issue tracking.
 
 ## Type of change
 
@@ -12,15 +16,15 @@ Moved the pull request template file to the `.github` folder and added a line fo
 
 ## Issue
 
-- [x] Is this related to a specific issue? If so, please specify:
+- [x] Is this related to a specific issue? If so, please specify:  
       Resolves #532
 
 # Checklist:
 
-- [x] This PR is up to date with the main branch, and merge conflicts have been resolved
-- [x] I have executed `npm run test` and `npm run test:e2e` and all tests have passed successfully or I have included details within my PR on the failure.
-- [x] I have executed `npm run lint` and resolved any outstanding errors. Most issues can be solved by executing `npm run format`
-- [x] My code follows the style guidelines of this project
-- [x] I have performed a self-review of my own code
-- [x] I have commented my code, particularly in hard-to-understand areas
+- [x] This PR is up to date with the main branch, and merge conflicts have been resolved  
+- [x] I have executed `npm run test` and `npm run test:e2e` and all tests have passed successfully or I have included details within my PR on the failure  
+- [x] I have executed `npm run lint` and resolved any outstanding errors. Most issues can be solved by executing `npm run format`  
+- [x] My code follows the style guidelines of this project  
+- [x] I have performed a self-review of my own code  
+- [x] I have commented my code, particularly in hard-to-understand areas  
 - [x] My changes generate no new warnings

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -15,6 +15,8 @@ Please select everything applicable. Please, do not delete any lines.
 ## Issue
 
 - [ ] Is this related to a specific issue? If so, please specify:
+      Resolves #532
+
 
 # Checklist:
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,29 +1,26 @@
 # Description
 
-Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. Additionally, please include reasoning if tests have failed.
+Moved the pull request template file to the `.github` folder and added a line for automatic issue linking (`Resolves #[issue]`). This change helps contributors properly link their PRs to issues and improves GitHub automation.
 
 ## Type of change
-
-Please select everything applicable. Please, do not delete any lines.
 
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-- [ ] This change requires a documentation update
+- [x] This change requires a documentation update
 - [ ] This change requires an update to testing
 
 ## Issue
 
-- [ ] Is this related to a specific issue? If so, please specify:
+- [x] Is this related to a specific issue? If so, please specify:
       Resolves #532
-
 
 # Checklist:
 
-- [ ] This PR is up to date with the main branch, and merge conflicts have been resolved
-- [ ] I have executed `npm run test` and `npm run test:e2e` and all tests have passed successfully or I have included details within my PR on the failure.
-- [ ] I have executed `npm run lint` and resolved any outstanding errors. Most issues can be solved by executing `npm run format`
-- [ ] My code follows the style guidelines of this project
-- [ ] I have performed a self-review of my own code
-- [ ] I have commented my code, particularly in hard-to-understand areas
-- [ ] My changes generate no new warnings
+- [x] This PR is up to date with the main branch, and merge conflicts have been resolved
+- [x] I have executed `npm run test` and `npm run test:e2e` and all tests have passed successfully or I have included details within my PR on the failure.
+- [x] I have executed `npm run lint` and resolved any outstanding errors. Most issues can be solved by executing `npm run format`
+- [x] My code follows the style guidelines of this project
+- [x] I have performed a self-review of my own code
+- [x] I have commented my code, particularly in hard-to-understand areas
+- [x] My changes generate no new warnings


### PR DESCRIPTION
# Description

Moved the pull request template file from `docs/pull_request_template.md` to `.github/pull_request_template.md`.  
Additionally, updated the template content to include a proper issue reference using the `Resolves #[issue]` keyword, which enables automatic issue closing by GitHub when the PR is merged.

## Type of change

Please select everything applicable. Please, do not delete any lines.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
- [ ] This change requires an update to testing

## Issue

- [x] Is this related to a specific issue? If so, please specify:  
      Resolves #532

# Checklist:

- [x] This PR is up to date with the main branch, and merge conflicts have been resolved  
- [x] I have executed `npm run test` and `npm run test:e2e` and all tests have passed successfully or I have included details within my PR on the failure  
- [x] I have executed `npm run lint` and resolved any outstanding errors. Most issues can be solved by executing `npm run format`  
- [x] My code follows the style guidelines of this project  
- [x] I have performed a self-review of my own code  
- [x] I have commented my code, particularly in hard-to-understand areas  
- [x] My changes generate no new warnings
