### PR TITLE
fixed header buttons on /calenadr

### DIFF
--- a/client/src/features/calendarHeader/CalendarHeader.jsx
+++ b/client/src/features/calendarHeader/CalendarHeader.jsx
@@ -19,7 +19,9 @@ function CalendarHeader({ date }) {
   const DISCORD_THREAD_URL =
     "discord://discord.com/channels/735923219315425401/1038482732633825442";
 
-  const GH_ISSUES_URL = "https://github.com/Together-100Devs/Together/issues";
+  const GH_DISCUSSIONS_URL =
+    "https://github.com/Together-100Devs/Together/discussions";
+  const GH_WIKI_URL = "https://github.com/Together-100Devs/Together/wiki";
 
   const linkToUrl = (url) => {
     window.open(url, "_blank");
@@ -67,12 +69,12 @@ function CalendarHeader({ date }) {
         <HeaderButton
           Icon={IoChatbubblesOutline}
           tooltipText="Feedback"
-          onClick={() => linkToUrl(GH_ISSUES_URL)}
+          onClick={() => linkToUrl(GH_DISCUSSIONS_URL)}
         />
         <HeaderButton
           Icon={FaQuestion}
           tooltipText="Help"
-          onClick={() => linkToUrl(GH_ISSUES_URL)}
+          onClick={() => linkToUrl(GH_WIKI_URL)}
         />
         {isAuthenticated() ? (
           <HeaderButton


### PR DESCRIPTION
# Description

Now, it links to [Discussions](https://github.com/Together-100Devs/Together/discussions) and [Wiki](https://github.com/Together-100Devs/Together/wiki)

Usually, there's no reason for users go to [Issues page](https://github.com/Together-100Devs/Together/issues), so I deleted that varaible

<img width="548" height="154" alt="image" src="https://github.com/user-attachments/assets/644642db-08ad-4e59-ac30-099c350ee3df" />


## Type of change

Please select everything applicable. Please, do not delete any lines.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change requires an update to testing

## Issue

- [x] Is this related to a specific issue? If so, please specify:
[#594](https://github.com/Together-100Devs/Together/issues/595)

# Checklist:

- [x] This PR is up to date with the main branch, and merge conflicts have been resolved
- [x] I have executed `npm run test` and `npm run test:e2e` and all tests have passed successfully or I have included details within my PR on the failure.
- [x] I have executed `npm run lint` and resolved any outstanding errors. Most issues can be solved by executing `npm run format`
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
