### PR TITLE
fixed ticket #640: event location links from going off screen

### DIFF
--- a/client/src/features/modal/EventModal.jsx
+++ b/client/src/features/modal/EventModal.jsx
@@ -106,7 +106,9 @@ const EventModal = () => {
           </section> */}
           <section className="flex m-3 gap-1 font-semibold">
             <IoLocationOutline className="mt-1" />{" "}
-            <span>Location: {modal.activeEvent.location}</span>
+            <span className="break-words w-full overflow-x-auto">
+              Location: {modal.activeEvent.location}
+            </span>
           </section>
           {user ? (
             <>


### PR DESCRIPTION
# Description

bugfix/issue #640 : fixed an issue when a user views an event. the location text overflows if it is too large.

## Type of change

Please select everything applicable. Please, do not delete any lines.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change requires an update to testing

## Issue

- [x] Is this related to a specific issue? If so, please specify: #640 

# Checklist:

- [x] This PR is up to date with the main branch, and merge conflicts have been resolved
- [x] I have executed `npm run test` and `npm run test:e2e` and all tests have passed successfully or I have included details within my PR on the failure.
- [x] I have executed `npm run lint` and resolved any outstanding errors. Most issues can be solved by executing `npm run format`
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
